### PR TITLE
Fix build args ordering and add bug test

### DIFF
--- a/travis2docker/test/main.py
+++ b/travis2docker/test/main.py
@@ -43,3 +43,12 @@ class MainTest(unittest.TestCase):
             default_docker_image='t2d_test',
             remotes=['moylop260', 'vauxoo-dev'])
         travis_obj.get_travis2docker()
+
+    def test_t2d_build_extra_args(self):
+        ''' Verify no error is thrown when extra-build-args are supplied '''
+        sys.argv = [
+            'travis2docker', self.repo_test, self.branch_test,
+            '--root-path=/tmp/t2d_tests',
+            '--build-extra-args="--disable-content-trust=true"',
+        ]
+        t2d_main()

--- a/travis2docker/travis2docker.py
+++ b/travis2docker/travis2docker.py
@@ -401,7 +401,7 @@ class travis(object):
             if fname_build:
                 with open(fname_build, "w") as fbuild:
                     fbuild.write(
-                        "#!/bin/bash\ndocker build $1 -t %s %s %s\n" % (
+                        "#!/bin/bash\ndocker build $1 %s -t %s %s\n" % (
                             self.build_extra_args,
                             image_name,
                             os.path.dirname(fname)


### PR DESCRIPTION
@moylop260 

Sorry when I switched to the new command, I flipped the str formatting around and put the build args when the tag should have been - resulting in an error. 

I fixed it, and added a test (because I should have done that anyways)