### PR TITLE
[REF] travis2docker: Add build rm default

### DIFF
--- a/travis2docker/travis2docker.py
+++ b/travis2docker/travis2docker.py
@@ -494,7 +494,7 @@ def main():
     parser.add_argument(
         '--build-extra-args', dest='build_extra_args',
         help="Extra arguments to `docker build BUILD_EXTRA_ARGS` command",
-        default='',
+        default='--rm',
     )
     args = parser.parse_args()
     sha = args.git_revision


### PR DESCRIPTION
 - When you run `docker build ...` generate intermediate containers that are removed if there isn't errors, but if there are errors then the container aren't removed.
 - The param `docker build --rm ..` force delete the intermediate containers.