### PR TITLE
[IMP] Add authorized_keys

### DIFF
--- a/travis2docker/travis2docker.py
+++ b/travis2docker/travis2docker.py
@@ -341,6 +341,7 @@ class travis(object):
                   "\nRUN find {1} ! -group {0} -exec {2} chown {0}:{0} {{}} \;".format(  # noqa
                         self.docker_user, home_user_path, sudo_prefix) + \
                   "\nRUN " + ' \\\n    && '.join(cmd_git_clone) + \
+                  "\nRUN ln -sf ~/.ssh/id_rsa.pub ~/.ssh/authorized_keys" \
                   "\n"
         return cmd
 

--- a/travis2docker/travis2docker.py
+++ b/travis2docker/travis2docker.py
@@ -264,13 +264,13 @@ class travis(object):
         )
         if self.command_format == 'bash':
             cmd = "\nsudo su - " + self.docker_user + \
-                  "\nfind {1} ! -group {0} -exec chown {0}:{0} {{}} \\;".format(  # noqa
-                        self.docker_user, home_user_path) + \
-                  "\nexport TRAVIS_BUILD_DIR=%s" % (travis_build_dir) + \
-                  "\ngit clone --single-branch %s -b %s " % (
-                      project, branch) + \
-                  "${TRAVIS_BUILD_DIR}" + \
-                  "\n"
+                  "\nfind {1} ! -group {0} -exec chown {0}:{0} {{}} \\;" \
+                .format(self.docker_user, home_user_path) + \
+                "\nexport TRAVIS_BUILD_DIR=%s" % (travis_build_dir) + \
+                "\ngit clone --single-branch %s -b %s " % (
+                    project, branch) + \
+                "${TRAVIS_BUILD_DIR}" + \
+                "\n"
         elif self.command_format == 'docker':
             dkr_files_path = os.path.join(dockerfile_path, "files")
             if not os.path.exists(dkr_files_path):
@@ -339,12 +339,12 @@ class travis(object):
                   "\nENV TRAVIS_BUILD_DIR=%s" % (travis_build_dir) + \
                   "\nWORKDIR ${TRAVIS_BUILD_DIR}" + \
                   "\nRUN find {1} ! -group {0} -exec {2} chown " \
-                       "{0}:{0} {{}} \\;".format(  # noqa
-                           self.docker_user, home_user_path, sudo_prefix) + \
-                  "\nRUN " + ' \\\n    && '.join(cmd_git_clone) + \
-                  "\nRUN cat ~/.ssh/id_rsa.pub | " \
-                        "tee -a ~/.ssh/authorized_keys" \
-                  "\n"
+                "{0}:{0} {{}} \\;".format(
+                self.docker_user, home_user_path, sudo_prefix) + \
+                "\nRUN " + ' \\\n    && '.join(cmd_git_clone) + \
+                "\nRUN cat ~/.ssh/id_rsa.pub | " \
+                "tee -a ~/.ssh/authorized_keys" \
+                "\n"
         return cmd
 
     def get_travis2docker_iter(self):

--- a/travis2docker/travis2docker.py
+++ b/travis2docker/travis2docker.py
@@ -341,7 +341,7 @@ class travis(object):
                   "\nRUN find {1} ! -group {0} -exec {2} chown {0}:{0} {{}} \;".format(  # noqa
                         self.docker_user, home_user_path, sudo_prefix) + \
                   "\nRUN " + ' \\\n    && '.join(cmd_git_clone) + \
-                  "\nRUN ln -sf ~/.ssh/id_rsa.pub ~/.ssh/authorized_keys" \
+                  "\nRUN cat ~/.ssh/id_rsa.pub | tee -a ~/.ssh/authorized_keys" \
                   "\n"
         return cmd
 

--- a/travis2docker/travis2docker.py
+++ b/travis2docker/travis2docker.py
@@ -338,10 +338,12 @@ class travis(object):
                   os.path.join(home_user_path, '.ssh') + \
                   "\nENV TRAVIS_BUILD_DIR=%s" % (travis_build_dir) + \
                   "\nWORKDIR ${TRAVIS_BUILD_DIR}" + \
-                  "\nRUN find {1} ! -group {0} -exec {2} chown {0}:{0} {{}} \;".format(  # noqa
-                        self.docker_user, home_user_path, sudo_prefix) + \
+                  "\nRUN find {1} ! -group {0} -exec {2} chown " \
+                       "{0}:{0} {{}} \\;".format(  # noqa
+                           self.docker_user, home_user_path, sudo_prefix) + \
                   "\nRUN " + ' \\\n    && '.join(cmd_git_clone) + \
-                  "\nRUN cat ~/.ssh/id_rsa.pub | tee -a ~/.ssh/authorized_keys" \
+                  "\nRUN cat ~/.ssh/id_rsa.pub | " \
+                        "tee -a ~/.ssh/authorized_keys" \
                   "\n"
         return cmd
 


### PR DESCRIPTION
This change adds public ssh key as authorized keys including `id_rsa.pub` key.

This is handy for `ssh` (of course) and when using `mosh`

Thanks @hbto for the hint

Demo:
[![](https://asciinema.org/a/0n09jwlglh0hkhxgqme79arza.png)](https://asciinema.org/a/0n09jwlglh0hkhxgqme79arza)