### PR TITLE
[IMP] templates: Support quay.io/travisci/travis-python image

### DIFF
--- a/src/travis2docker/templates/Dockerfile
+++ b/src/travis2docker/templates/Dockerfile
@@ -8,6 +8,10 @@ ENV HOME=
 /home/{{ user }}
 {%- endif %}
 
+{% if image == 'quay.io/travisci/travis-python' -%}
+ENV PATH=${PATH}:/home/travis/.nvm/v0.10.36/bin:/home/travis/.nvm/v0.10.36/lib/node_modules/npm/bin
+{%- endif %}
+
 {%- for src, dest in copies %}
 ADD {{ src }} {{ dest }}
 RUN chown -R {{ user }}:{{ user }} {{dest}}
@@ -46,6 +50,10 @@ ENV {{ env }}
 WORKDIR ${TRAVIS_BUILD_DIR}
 
 {%- for run in runs %}
+{% if image == 'quay.io/travisci/travis-python' -%}
+RUN /bin/bash -c "source $HOME/virtualenv/python2.7_with_system_site_packages/bin/activate && {{ run }}"
+{%- endif %}
+{% else %}
 RUN {{ run }}
 {%- endfor %}
 ENTRYPOINT /entrypoint.sh

--- a/src/travis2docker/templates/entrypoint.sh
+++ b/src/travis2docker/templates/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+{% if image == 'quay.io/travisci/travis-python' -%}
+source /home/travis/virtualenv/python2.7_with_system_site_packages/bin/activate
+{%- endif %}
 {% for entrypoint in entrypoints %}
 {{ entrypoint }}
 {% endfor %}


### PR DESCRIPTION
The image of travis for python use a virtual environment and a pre-installed npm