### PR TITLE
[ADD] Dockerfile: Support for RVM

### DIFF
--- a/src/travis2docker/templates/Dockerfile
+++ b/src/travis2docker/templates/Dockerfile
@@ -26,6 +26,10 @@ RUN apt-get update; apt-get install {{ ' '.join(packages) }}
 {%- endif %}
 
 USER {{ user }}
+
+# Install RVM
+RUN \curl -L https://get.rvm.io | bash -s stable
+
 ENV TRAVIS_REPO_SLUG={{ repo_owner }}/{{ repo_project }}
 ENV TRAVIS_BUILD_DIR=${HOME}/build/${TRAVIS_REPO_SLUG}
 RUN git init ${TRAVIS_BUILD_DIR} \
@@ -58,9 +62,9 @@ WORKDIR ${TRAVIS_BUILD_DIR}
 
 {% if runs -%}
 {% if image == 'quay.io/travisci/travis-python' -%}
-RUN /bin/bash -c "source $HOME/virtualenv/python2.7_with_system_site_packages/bin/activate && {{ ' && '.join(runs) }}"
+RUN /bin/bash -c "source $HOME/virtualenv/python2.7_with_system_site_packages/bin/activate && source /usr/local/rvm/scripts/rvm && {{ ' && '.join(runs) }}"
 {% else %}
-RUN {{ ' && '.join(runs) }}
+RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && {{ ' && '.join(runs) }}"
 {%- endif %}
 {%- endif %}
 ENTRYPOINT /entrypoint.sh

--- a/src/travis2docker/templates/entrypoint.sh
+++ b/src/travis2docker/templates/entrypoint.sh
@@ -2,6 +2,7 @@
 {% if image == 'quay.io/travisci/travis-python' -%}
 source /home/travis/virtualenv/python2.7_with_system_site_packages/bin/activate
 {%- endif %}
+source /usr/local/rvm/scripts/rvm
 {% for entrypoint in entrypoints %}
 {{ entrypoint }}
 {% endfor %}

--- a/tests/test_travis2docker.py
+++ b/tests/test_travis2docker.py
@@ -45,7 +45,11 @@ def test_main():
     dirname_example = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), '..', 'examples')
     argv = ['travis2docker', 'foo', 'bar', '--no-clone']
-    lines_required = ['RUN /install', 'ENTRYPOINT /entrypoint.sh']
+    lines_required = [
+        'RUN \curl -L https://get.rvm.io | /bin/bash -s stable',
+        'RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && /install"',
+        'ENTRYPOINT /entrypoint.sh',
+    ]
 
     example = os.path.join(dirname_example, 'example_1.yml')
     sys.argv = argv + ['--travis-yml-path', example]


### PR DESCRIPTION
After implementing this in the Odoo Docker image, I realized I was going to have to make changes here too. 

I realized also that Odoo doesn't require any of this, but a Travis environment is assumed to have it. 

With the above in mind, the whole thing is now implemented here.

* Add RVM install
* Add bash encapsulation for install commands

Fixes #74. Test build was performed against branch of OCA/website#284 with great success! :borat: