### PR TITLE
[IMP] travis2docker: Adding the possibility to support many version of python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python: '3.5'
 sudo: false
+dist: precise
 env:
   global:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so

--- a/src/travis2docker/templates/Dockerfile
+++ b/src/travis2docker/templates/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update; apt-get install {{ ' '.join(packages) }}
 {%- endif %}
 
 USER {{ user }}
+ENV TRAVIS_PYTHON_VERSION={{ python_version }}
 ENV TRAVIS_REPO_SLUG={{ repo_owner }}/{{ repo_project }}
 ENV TRAVIS_BUILD_DIR=${HOME}/build/${TRAVIS_REPO_SLUG}
 RUN git init ${TRAVIS_BUILD_DIR} \
@@ -62,9 +63,9 @@ WORKDIR ${TRAVIS_BUILD_DIR}
 
 {% if runs -%}
 {% if image == 'quay.io/travisci/travis-python' -%}
-RUN /bin/bash -c "source $HOME/virtualenv/python2.7_with_system_site_packages/bin/activate && source /rvm_env.sh && {{ ' && '.join(runs) }}"
+RUN /bin/bash -c "source $HOME/virtualenv/python{{ python_version }}_with_system_site_packages/bin/activate && source /rvm_env.sh && {{ ' && '.join(runs) }}"
 {% elif  image == 'vauxoo/odoo-80-image-shippable-auto' -%}
-RUN /bin/bash -c "source ${REPO_REQUIREMENTS}/virtualenv/python2.7/bin/activate && source ${REPO_REQUIREMENTS}/virtualenv/nodejs/bin/activate && source /rvm_env.sh && {{ ' && '.join(runs) }}"
+RUN /bin/bash -c "source ${REPO_REQUIREMENTS}/virtualenv/python{{ python_version }}/bin/activate && source ${REPO_REQUIREMENTS}/virtualenv/nodejs/bin/activate && source /rvm_env.sh && {{ ' && '.join(runs) }}"
 {% else %}
 RUN /bin/bash -c "source /rvm_env.sh && {{ ' && '.join(runs) }}"
 {%- endif %}

--- a/src/travis2docker/templates/entrypoint.sh
+++ b/src/travis2docker/templates/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 {% if image == 'quay.io/travisci/travis-python' -%}
-source /home/travis/virtualenv/python2.7_with_system_site_packages/bin/activate
+source /home/travis/virtualenv/python{{ python_version }}_with_system_site_packages/bin/activate
 {% elif  image == 'vauxoo/odoo-80-image-shippable-auto' -%}
-source ${REPO_REQUIREMENTS}/virtualenv/python2.7/bin/activate && source ${REPO_REQUIREMENTS}/virtualenv/nodejs/bin/activate
+source ${REPO_REQUIREMENTS}/virtualenv/python{{ python_version }}/bin/activate && source ${REPO_REQUIREMENTS}/virtualenv/nodejs/bin/activate
 {%- endif %}
 source /rvm_env.sh
 {% for entrypoint in entrypoints %}

--- a/src/travis2docker/travis2docker.py
+++ b/src/travis2docker/travis2docker.py
@@ -62,7 +62,6 @@ class Travis2Docker(object):
                  templates_path=None, os_kwargs=None, copy_paths=None,
                  ):
         self._python_versions = ['2.7']
-        self._supported_versions = ('2.7' '3.2' '3.3' '3.4' '3.5' '3.6')
         self.curr_work_path = None
         self.curr_exports = []
         self.build_extra_params = {}
@@ -229,8 +228,7 @@ class Travis2Docker(object):
         if not versions:
             return False
         for version in versions:
-            if (version not in self._supported_versions or
-                    version in self._python_versions):
+            if version in self._python_versions:
                 continue
             self._python_versions.append(version)
 

--- a/src/travis2docker/travis2docker.py
+++ b/src/travis2docker/travis2docker.py
@@ -227,6 +227,8 @@ class Travis2Docker(object):
         versions = self.yml.pop('python', {})
         if not versions:
             return False
+        if not isinstance(versions, list):
+            versions = [versions]
         for version in versions:
             if version in self._python_versions:
                 continue

--- a/src/travis2docker/travis2docker.py
+++ b/src/travis2docker/travis2docker.py
@@ -61,7 +61,7 @@ class Travis2Docker(object):
     def __init__(self, yml_buffer, image=None, work_path=None, dockerfile=None,
                  templates_path=None, os_kwargs=None, copy_paths=None,
                  ):
-        self._python_versions = ['2.7']
+        self._python_versions = []
         self.curr_work_path = None
         self.curr_exports = []
         self.build_extra_params = {}

--- a/src/travis2docker/travis2docker.py
+++ b/src/travis2docker/travis2docker.py
@@ -61,6 +61,8 @@ class Travis2Docker(object):
     def __init__(self, yml_buffer, image=None, work_path=None, dockerfile=None,
                  templates_path=None, os_kwargs=None, copy_paths=None,
                  ):
+        self._python_versions = ['2.7']
+        self._supported_versions = ('2.7' '3.2' '3.3' '3.4' '3.5' '3.6')
         self.curr_work_path = None
         self.curr_exports = []
         self.build_extra_params = {}
@@ -194,10 +196,11 @@ class Travis2Docker(object):
         self.curr_work_path = None
         self.curr_exports = []
 
-    def compute_build_scripts(self, prefix_build):
+    def compute_build_scripts(self, prefix_build, version):
         build_path = os.path.join(self.curr_work_path, "10-build.sh")
         run_path = os.path.join(self.curr_work_path, "20-run.sh")
-        new_image = self.new_image + '_' + str(prefix_build)
+        new_image = (self.new_image + '_' + version.replace('.', '_') + '_' +
+                     str(prefix_build))
         with open(build_path, "w") as f_build, \
                 open(run_path, "w") as f_run:
             build_content = self.build_template.render(
@@ -221,6 +224,16 @@ class Travis2Docker(object):
         self.chmod_execution(build_path)
         self.chmod_execution(run_path)
 
+    def _python_version_env(self):
+        versions = self.yml.pop('python', {})
+        if not versions:
+            return False
+        for version in versions:
+            if (version not in self._supported_versions or
+                    version in self._python_versions):
+                continue
+            self._python_versions.append(version)
+
     def _transform_yml_matrix2env(self):
         matrix = self.yml.pop('matrix', {})
         envs = [include['env'] for include in matrix.get('include', [])
@@ -231,65 +244,72 @@ class Travis2Docker(object):
     def compute_dockerfile(self, skip_after_success=False):
         work_paths = []
         self._transform_yml_matrix2env()
-        for count, env in enumerate(self._compute('env') or [], 1):
-            self.reset()
-            self.curr_work_path = os.path.join(self.work_path, str(count))
-            curr_dockerfile = \
-                os.path.join(self.curr_work_path, self.dockerfile)
-            entryp_path = os.path.join(self.curr_work_path, "files",
-                                       "entrypoint.sh")
-            self.mkdir_p(os.path.dirname(entryp_path))
-            entryp_relpath = os.path.relpath(entryp_path, self.curr_work_path)
-            rvm_env_path = os.path.join(self.curr_work_path, "files",
-                                        "rvm_env.sh")
-            rvm_env_relpath = os.path.relpath(rvm_env_path, self.curr_work_path)
-            copies = []
-            for copy_path, dest in self.copy_paths:
-                copies.append((self.copy_path(copy_path), dest))
-            kwargs = {'runs': [], 'copies': copies, 'entrypoints': [],
-                      'entrypoint_path': entryp_relpath, 'image': self.image,
-                      'env': env, 'packages': [], 'sources': [],
-                      'rvm_env_path': rvm_env_relpath,
-                      }
-            with open(curr_dockerfile, "w") as f_dockerfile, \
-                    open(entryp_path, "w") as f_entrypoint, \
-                    open(rvm_env_path, "w") as f_rvm:
-                for section, _ in self._sections.items():
-                    if section == 'env':
-                        continue
-                    if skip_after_success and section == 'after_success':
-                        continue
-                    result = self._compute(section)
-                    if not result:
-                        continue
-                    keys_to_extend = ['copies', 'runs', 'entrypoints',
-                                      'packages', 'sources'] \
-                        if isinstance(result, dict) else []
-                    for key_to_extend in keys_to_extend:
-                        if key_to_extend in result:
-                            kwargs[key_to_extend].extend(result[key_to_extend])
-                kwargs.update(self.os_kwargs)
-                dockerfile_content = \
-                    self.dockerfile_template.render(kwargs).strip('\n ')
-                try:
-                    f_dockerfile.write(dockerfile_content.encode('utf-8'))
-                except TypeError:
-                    f_dockerfile.write(dockerfile_content)
-                entrypoint_content = \
-                    self.entrypoint_template.render(kwargs).strip('\n ')
-                try:
-                    f_entrypoint.write(entrypoint_content.encode('utf-8'))
-                except TypeError:
-                    f_entrypoint.write(entrypoint_content)
-                rvm_env_content = self.jinja_env.get_template(
-                    'rvm_env.sh').render(kwargs).strip('\n ')
-                try:
-                    f_rvm.write(rvm_env_content.encode('UTF-8'))
-                except TypeError:
-                    f_rvm.write(rvm_env_content)
-            self.compute_build_scripts(count)
-            self.chmod_execution(entryp_path)
-            work_paths.append(self.curr_work_path)
+        self._python_version_env()
+        for version in self._python_versions:
+            for count, env in enumerate(self._compute('env') or [], 1):
+                self.reset()
+                self.curr_work_path = os.path.join(self.work_path,
+                                                   version.replace('.', '_'),
+                                                   str(count))
+                curr_dockerfile = \
+                    os.path.join(self.curr_work_path, self.dockerfile)
+                entryp_path = os.path.join(self.curr_work_path, "files",
+                                           "entrypoint.sh")
+                self.mkdir_p(os.path.dirname(entryp_path))
+                entryp_relpath = os.path.relpath(entryp_path,
+                                                 self.curr_work_path)
+                rvm_env_path = os.path.join(self.curr_work_path, "files",
+                                            "rvm_env.sh")
+                rvm_env_relpath = os.path.relpath(rvm_env_path,
+                                                  self.curr_work_path)
+                copies = []
+                for copy_path, dest in self.copy_paths:
+                    copies.append((self.copy_path(copy_path), dest))
+                kwargs = {'runs': [], 'copies': copies, 'entrypoints': [],
+                          'entrypoint_path': entryp_relpath,
+                          'python_version': version,
+                          'image': self.image, 'env': env, 'packages': [],
+                          'sources': [], 'rvm_env_path': rvm_env_relpath}
+                with open(curr_dockerfile, "w") as f_dockerfile, \
+                        open(entryp_path, "w") as f_entrypoint, \
+                        open(rvm_env_path, "w") as f_rvm:
+                    for section, _ in self._sections.items():
+                        if section == 'env':
+                            continue
+                        if skip_after_success and section == 'after_success':
+                            continue
+                        result = self._compute(section)
+                        if not result:
+                            continue
+                        keys_to_extend = ['copies', 'runs', 'entrypoints',
+                                          'packages', 'sources'] \
+                            if isinstance(result, dict) else []
+                        for key_to_extend in keys_to_extend:
+                            if key_to_extend in result:
+                                kwargs[key_to_extend].extend(
+                                    result[key_to_extend])
+                    kwargs.update(self.os_kwargs)
+                    dockerfile_content = \
+                        self.dockerfile_template.render(kwargs).strip('\n ')
+                    try:
+                        f_dockerfile.write(dockerfile_content.encode('utf-8'))
+                    except TypeError:
+                        f_dockerfile.write(dockerfile_content)
+                    entrypoint_content = \
+                        self.entrypoint_template.render(kwargs).strip('\n ')
+                    try:
+                        f_entrypoint.write(entrypoint_content.encode('utf-8'))
+                    except TypeError:
+                        f_entrypoint.write(entrypoint_content)
+                    rvm_env_content = self.jinja_env.get_template(
+                        'rvm_env.sh').render(kwargs).strip('\n ')
+                    try:
+                        f_rvm.write(rvm_env_content.encode('UTF-8'))
+                    except TypeError:
+                        f_rvm.write(rvm_env_content)
+                self.compute_build_scripts(count, version)
+                self.chmod_execution(entryp_path)
+                work_paths.append(self.curr_work_path)
         self.reset()
         return work_paths
 

--- a/tests/test_travis2docker.py
+++ b/tests/test_travis2docker.py
@@ -109,6 +109,8 @@ def test_main():
     url = 'https://github.com/Vauxoo/travis2docker.git'
     sys.argv = ['travis2docker', url, 'master']
     scripts = main()
+    sources_py = ("source ${REPO_REQUIREMENTS}/virtualenv/"
+                  "python3.5/bin/activate")
     lines_required.pop(0)
     lines_required.append(
         'RUN /bin/bash -c "{source_py} && {source_js} && '


### PR DESCRIPTION
With this change now the `travis2docker` can be support many version of python 
The list of version of python are :
```
- 2.7
- 3.2
- 3.3
- 3.4
- 3.5
- 3.6
```

Now for each version inside the `.travis.yml` travis2docker creates a folder with the number of the python version

For example if I made o travis2docker over the follow repository git@github.com:vauxoo-dev/asdcust.git using the branch 10.0-two-version

```
Script generated: 
/tmp/travis2docker/script/git_github.com_vauxoo-dev_asdcust.git/10.0-two-version/2_7/1
/tmp/travis2docker/script/git_github.com_vauxoo-dev_asdcust.git/10.0-two-version/2_7/2
/tmp/travis2docker/script/git_github.com_vauxoo-dev_asdcust.git/10.0-two-version/3_5/1
/tmp/travis2docker/script/git_github.com_vauxoo-dev_asdcust.git/10.0-two-version/3_5/2
```
And the Dockerfile contains the environment variable `TRAVIS_PYTHON_VERSION` is that used by travis https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables

And the name of the image was changed for the follow format
```
vauxoo-dev-asdcust:10_0-two-version_3_5_2
```



