### PR TITLE
[FIX] travis2docker: Fix the name of the python version in travis image

### DIFF
--- a/src/travis2docker/templates/Dockerfile
+++ b/src/travis2docker/templates/Dockerfile
@@ -63,7 +63,7 @@ WORKDIR ${TRAVIS_BUILD_DIR}
 
 {% if runs -%}
 {% if image == 'quay.io/travisci/travis-python' -%}
-RUN /bin/bash -c "source $HOME/virtualenv/python{{ python_version }}_with_system_site_packages/bin/activate && source /rvm_env.sh && {{ ' && '.join(runs) }}"
+RUN /bin/bash -c "source $HOME/virtualenv/python{{ python_version }}/bin/activate && source /rvm_env.sh && {{ ' && '.join(runs) }}"
 {% elif  image == 'vauxoo/odoo-80-image-shippable-auto' -%}
 RUN /bin/bash -c "source ${REPO_REQUIREMENTS}/virtualenv/python{{ python_version }}/bin/activate && source ${REPO_REQUIREMENTS}/virtualenv/nodejs/bin/activate && source /rvm_env.sh && {{ ' && '.join(runs) }}"
 {% else %}

--- a/src/travis2docker/templates/entrypoint.sh
+++ b/src/travis2docker/templates/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 {% if image == 'quay.io/travisci/travis-python' -%}
-source /home/travis/virtualenv/python{{ python_version }}_with_system_site_packages/bin/activate
+source /home/travis/virtualenv/python{{ python_version }}/bin/activate
 {% elif  image == 'vauxoo/odoo-80-image-shippable-auto' -%}
 source ${REPO_REQUIREMENTS}/virtualenv/python{{ python_version }}/bin/activate && source ${REPO_REQUIREMENTS}/virtualenv/nodejs/bin/activate
 {%- endif %}


### PR DESCRIPTION
Only use the name of the `python` version not use the sub fix `_with_system_site_packages`

To avoid additional  validation when the `travis` imagen is used

![image](https://user-images.githubusercontent.com/1387970/30760018-7adee794-9fa6-11e7-9e56-b86b3dc5ccec.png)
