### PR TITLE
[FIX] entrypoin.sh: Fix the python version when the user made ssh login using the file /etc/environment

### DIFF
--- a/src/travis2docker/templates/Dockerfile
+++ b/src/travis2docker/templates/Dockerfile
@@ -27,6 +27,8 @@ RUN {{ ' && '.join(sources)  }}
 RUN apt-get update; apt-get install {{ ' '.join(packages) }}
 {%- endif %}
 
+RUN echo "TRAVIS_PYTHON_VERSION={{ python_version }}" >> /etc/environment
+
 USER {{ user }}
 ENV TRAVIS_PYTHON_VERSION={{ python_version }}
 ENV TRAVIS_REPO_SLUG={{ repo_owner }}/{{ repo_project }}


### PR DESCRIPTION
With this change when the user made ssh login over the container the file `/etc/environment` load the correct version of python

Fix https://github.com/Vauxoo/travis2docker/issues/108