### PR TITLE
[FIX] travis2docker.py: Diferent type of matrix in .travis.yml

### DIFF
--- a/examples/example_5.yml
+++ b/examples/example_5.yml
@@ -1,0 +1,47 @@
+language: python
+
+sudo: false
+cache:
+  apt: true
+  directories:
+    - $HOME/.cache/pip
+
+addons:
+  apt:
+    sources:
+      - pov-wkhtmltopdf
+      - chef-stable-trusty
+    packages:
+      - python-lxml
+      - wkhtmltopdf
+      - chefdk
+
+python:
+  - "2.7"
+
+env:
+  global:
+    - GLOBAL="global variable"
+  matrix:
+    - MATRIX="matrix build"
+
+matrix:
+  include:
+    - python: 2.7
+      env:
+        VARIABLE_INCLUDE_1="value include 1"
+    - python: 3.5
+      env:
+        VARIABLE_INCLUDE_2="value include 2"
+
+virtualenv:
+  system_site_packages: true
+
+install:
+  - touch install
+
+script:
+  - touch script
+
+after_success:
+  - touch after_success

--- a/src/travis2docker/travis2docker.py
+++ b/src/travis2docker/travis2docker.py
@@ -120,9 +120,8 @@ class Travis2Docker(object):
         return job_method(section_data, section)
 
     def _compute_env_global(self, data, _):
-        globals = (self.yml.get('env').get('global')
-                   if isinstance(self.yml.get('env'), dict) else [])
-        return globals
+        return (self.yml.get('env').get('global')
+                if isinstance(self.yml.get('env'), dict) else [])
 
     def _compute_run(self, data, section):
         args = self._make_script(data, section, add_run=True, prefix='files')
@@ -233,11 +232,11 @@ class Travis2Docker(object):
         envs = []
         if not self.yml.get('env'):
             return envs
-        globals = self._compute('env_global')
+        env_globals = self._compute('env_global')
         values = (self.yml.get('env').get('matrix', [])
                   if isinstance(self.yml.get('env'), dict)
                   else self.yml.get('env', []))
-        envs = [(" ".join(globals) + " " + env).strip() for env in values]
+        envs = [(" ".join(env_globals) + " " + env).strip() for env in values]
         return envs
 
     def _transform_yml_matrix2env(self):
@@ -249,12 +248,12 @@ class Travis2Docker(object):
                           - VARIABLE="value"
         """
         envs = []
-        globals = self._compute('env_global')
+        env_globals = self._compute('env_global')
         matrix = self.yml.pop('matrix', {})
         for include in matrix.get('include', []):
             env = {}
             if include.get('env', False) and include.get('python', False):
-                env['env'] = (" ".join(globals) + " " +
+                env['env'] = (" ".join(env_globals) + " " +
                               include.get('env')).strip()
                 env['python'] = include.get('python')
                 envs.append(env)

--- a/src/travis2docker/travis2docker.py
+++ b/src/travis2docker/travis2docker.py
@@ -87,7 +87,6 @@ class Travis2Docker(object):
             jinja2.Environment(loader=jinja2.FileSystemLoader(templates_path))
         self.image = image
         self._sections = collections.OrderedDict()
-        self._sections['env'] = 'env'
         self._sections['env_global'] = 'env_global'
         self._sections['addons'] = 'addons'
         self._sections['before_install'] = 'run'
@@ -113,7 +112,7 @@ class Travis2Docker(object):
         if not section_type:
             return None
         section_data = self.yml.get(section, "")
-        if section not in ("env", "env_global") and not section_data:
+        if section != 'env_global' and not section_data:
             return None
         if not isinstance(section_data, (list, dict, tuple)):
             section_data = [section_data]

--- a/src/travis2docker/travis2docker.py
+++ b/src/travis2docker/travis2docker.py
@@ -225,6 +225,11 @@ class Travis2Docker(object):
             self._python_versions.append(version)
 
     def _transform_yml_envmatrix2env(self):
+        """This method get the environment variables in the follow format
+            env:
+                matrix:
+                    - VARIABLE="value"
+        """
         envs = []
         if not self.yml.get('env'):
             return envs
@@ -236,6 +241,13 @@ class Travis2Docker(object):
         return envs
 
     def _transform_yml_matrix2env(self):
+        """This method get the environment variables in the follow format
+            matrix:
+                include:
+                    - python: 2.7
+                      env:
+                          - VARIABLE="value"
+        """
         envs = []
         globals = self._compute('env_global')
         matrix = self.yml.pop('matrix', {})

--- a/tests/test_travis2docker.py
+++ b/tests/test_travis2docker.py
@@ -106,6 +106,20 @@ def test_main():
         dkr_content = f_dkr.read()
         assert 'VARIABLE_INCLUDE_2="value include 2"' in dkr_content
 
+    example = os.path.join(dirname_example, 'example_5.yml')
+    sys.argv = argv + ['--travis-yml-path', example]
+    scripts = main()
+    assert len(scripts) == 2, 'Scripts returned should be 2 for %s' % example
+    check_failed_dockerfile(scripts)
+    with open(os.path.join(scripts[0], 'Dockerfile')) as f_dkr:
+        dkr_content = f_dkr.read()
+        assert 'VARIABLE_INCLUDE_1="value include 1"' in dkr_content
+        assert 'ENV TRAVIS_PYTHON_VERSION=2.7' in dkr_content
+    with open(os.path.join(scripts[1], 'Dockerfile')) as f_dkr:
+        dkr_content = f_dkr.read()
+        assert 'VARIABLE_INCLUDE_2="value include 2"' in dkr_content
+        assert 'ENV TRAVIS_PYTHON_VERSION=3.5' in dkr_content
+
     url = 'https://github.com/Vauxoo/travis2docker.git'
     sys.argv = ['travis2docker', url, 'master']
     scripts = main()


### PR DESCRIPTION
This pull request support the follow format:

```yml
language: python

...

python:
  - "2.7"
  - "3.5"

env:
  global:
    - LINT_CHECK="0" TESTS="0"
    - VERSION="10.0" ODOO_REPO="vauxoo/odoo"
    - INCLUDE="asdcust"
  matrix:
    - LINT_CHECK="1" ENV="1"
    - TESTS="1" ENV="1"

matrix:
  include:
    - python: 2.7
      env:
        LINT_CHECK="1" MATRIX="1"
    - python: 2.7
      env:
        TESTS="1" MATRIX="1"
    - python: 3.5
      env:
        LINT_CHECK="1" MATRIX="1"
    - python: 3.5
      env:
        TESTS="1" MATRIX="1"

...
```

This `.travis.yml` file generated the follow output 

```bash
Script generated: 
/tmp/travis2docker/script/git_github.com_project.git/10.0-two-version-matrix-mix/2_7/1
/tmp/travis2docker/script/git_github.com_project.git/10.0-two-version-matrix-mix/2_7/2
/tmp/travis2docker/script/git_github.com_project.git/10.0-two-version-matrix-mix/3_5/1
/tmp/travis2docker/script/git_github.com_project.git/10.0-two-version-matrix-mix/3_5/2
/tmp/travis2docker/script/git_github.com_project.git/10.0-two-version-matrix-mix/2_7/1
/tmp/travis2docker/script/git_github.com_project.git/10.0-two-version-matrix-mix/2_7/2
/tmp/travis2docker/script/git_github.com_project.git/10.0-two-version-matrix-mix/3_5/1
/tmp/travis2docker/script/git_github.com_project.git/10.0-two-version-matrix-mix/3_5/2
```
