### PR TITLE
Revert "[IMP] templates: Using virtualenv for each odoo version to faster installation"

### DIFF
--- a/src/travis2docker/templates/Dockerfile
+++ b/src/travis2docker/templates/Dockerfile
@@ -71,7 +71,7 @@ WORKDIR ${TRAVIS_BUILD_DIR}
 {% if image == 'quay.io/travisci/travis-python' -%}
 RUN /bin/bash -c "source $HOME/virtualenv/python{{ python_version }}/bin/activate && source /rvm_env.sh && {{ ' && '.join(runs) }}"
 {% elif  image == 'vauxoo/odoo-80-image-shippable-auto' -%}
-RUN ln -s ${REPO_REQUIREMENTS}/virtualenv/python{{ python_version }} ${REPO_REQUIREMENTS}/virtualenv/python{{ python_version }}${VERSION} || true && /bin/bash -c "source ${REPO_REQUIREMENTS}/virtualenv/python{{ python_version }}${VERSION}/bin/activate && source ${REPO_REQUIREMENTS}/virtualenv/nodejs/bin/activate && source /rvm_env.sh && {{ ' && '.join(runs) }}"
+RUN /bin/bash -c "source ${REPO_REQUIREMENTS}/virtualenv/python{{ python_version }}/bin/activate && source ${REPO_REQUIREMENTS}/virtualenv/nodejs/bin/activate && source /rvm_env.sh && {{ ' && '.join(runs) }}"
 {% else %}
 RUN /bin/bash -c "source /rvm_env.sh && {{ ' && '.join(runs) }}"
 {%- endif %}

--- a/src/travis2docker/templates/entrypoint.sh
+++ b/src/travis2docker/templates/entrypoint.sh
@@ -2,9 +2,7 @@
 {% if image == 'quay.io/travisci/travis-python' -%}
 source /home/travis/virtualenv/python{{ python_version }}/bin/activate
 {% elif  image == 'vauxoo/odoo-80-image-shippable-auto' -%}
-# Compatibility with old images without virtualenv for each odoo version
-ln -s ${REPO_REQUIREMENTS}/virtualenv/python{{ python_version }} ${REPO_REQUIREMENTS}/virtualenv/python{{ python_version }}${VERSION} || true
-source ${REPO_REQUIREMENTS}/virtualenv/python{{ python_version }}${VERSION}/bin/activate && source ${REPO_REQUIREMENTS}/virtualenv/nodejs/bin/activate
+source ${REPO_REQUIREMENTS}/virtualenv/python{{ python_version }}/bin/activate && source ${REPO_REQUIREMENTS}/virtualenv/nodejs/bin/activate
 {%- endif %}
 source /rvm_env.sh
 {% for entrypoint in entrypoints %}

--- a/tests/test_travis2docker.py
+++ b/tests/test_travis2docker.py
@@ -45,14 +45,11 @@ def test_main():
     dirname_example = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), '..', 'examples')
     argv = ['travis2docker', 'foo', 'bar', '--no-clone']
-
     sources_py = ("source ${REPO_REQUIREMENTS}/virtualenv/"
-                  "python2.7${VERSION}/bin/activate")
+                  "python2.7/bin/activate")
     sources_js = "source ${REPO_REQUIREMENTS}/virtualenv/nodejs/bin/activate"
     lines_required = [
-        'RUN ln -s ${{REPO_REQUIREMENTS}}/virtualenv/python2.7 '
-        '${{REPO_REQUIREMENTS}}/virtualenv/python2.7${{VERSION}} || true && '
-        '/bin/bash -c "{source_py} && {source_js} '
+        'RUN /bin/bash -c "{source_py} && {source_js} '
         '&& source /rvm_env.sh && /install"'.
         format(source_py=sources_py, source_js=sources_js),
         'ENTRYPOINT /entrypoint.sh',
@@ -113,12 +110,10 @@ def test_main():
     sys.argv = ['travis2docker', url, 'master']
     scripts = main()
     sources_py = ("source ${REPO_REQUIREMENTS}/virtualenv/"
-                  "python3.5${VERSION}/bin/activate")
+                  "python3.5/bin/activate")
     lines_required.pop(0)
     lines_required.append(
-        'RUN ln -s ${{REPO_REQUIREMENTS}}/virtualenv/python3.5 '
-        '${{REPO_REQUIREMENTS}}/virtualenv/python3.5${{VERSION}} || true && '
-        '/bin/bash -c "{source_py} && {source_js} && '
+        'RUN /bin/bash -c "{source_py} && {source_js} && '
         'source /rvm_env.sh && '
         '/before_install && /install"'.
         format(source_py=sources_py, source_js=sources_js),


### PR DESCRIPTION
    This reverts PR https://github.com/Vauxoo/travis2docker/pull/111
    This reverts PR https://github.com/Vauxoo/travis2docker/pull/112

    This reverts commit 1bf31d2dff086a4b8b57cd405af344238e62edb1.
    This reverts commit f39fb717b5f3ce48f8c80b5f0b0fec2fcc86656e.
    This reverts commit b14ca3db21786ea1464bc1db525932219b8f86b3.

    There are too many tests to do before releasing this logic,
    runbot_travis2docker tests failing with the new base image and new t2d
    release.