### PR TITLE
[IMP] travis2docker: Add support for key to specify PostgreSQL version

### DIFF
--- a/examples/example_5.yml
+++ b/examples/example_5.yml
@@ -1,0 +1,42 @@
+language: python
+
+sudo: false
+cache:
+  apt: true
+  directories:
+    - $HOME/.cache/pip
+
+addons:
+  postgresql: "9.5"
+  apt:
+    sources:
+      - pov-wkhtmltopdf
+      - chef-stable-trusty
+    packages:
+      - python-lxml
+      - wkhtmltopdf
+      - chefdk
+
+python:
+  - "2.7"
+
+matrix:
+  include:
+    - python: 2.7
+      env:
+        VARIABLE_INCLUDE_1="value include 1"
+    - python: 2.7
+      env:
+        VARIABLE_INCLUDE_2="value include 2"
+
+virtualenv:
+  system_site_packages: true
+
+install:
+  - touch install
+
+script:
+  - touch script
+
+after_success:
+  - touch after_success

--- a/src/travis2docker/travis2docker.py
+++ b/src/travis2docker/travis2docker.py
@@ -119,8 +119,7 @@ class Travis2Docker(object):
         job_method = getattr(self, '_compute_' + section_type)
         return job_method(section_data, section)
 
-    @staticmethod
-    def _compute_env(data, _):
+    def _compute_env(self, data, _):
         if isinstance(data, list):
             # old version without matrix
             data = {'matrix': data}
@@ -131,6 +130,9 @@ class Travis2Docker(object):
                 continue
             env_globals += " " + env_global
         env_globals = env_globals.strip()
+        psql_version = (self.yml.get('addons') or {}).get('postgresql')
+        if psql_version:
+            env_globals += ' PSQL_VERSION="%s"' % psql_version
         for env_matrix in data.get('matrix', []):
             yield (env_globals + " " + env_matrix).strip()
 

--- a/tests/test_travis2docker.py
+++ b/tests/test_travis2docker.py
@@ -106,6 +106,20 @@ def test_main():
         dkr_content = f_dkr.read()
         assert 'VARIABLE_INCLUDE_2="value include 2"' in dkr_content
 
+    # Tests that, when specified, the postgresql key sets
+    # automatically the environment variable $PSQL_VERSION
+    example = os.path.join(dirname_example, 'example_5.yml')
+    sys.argv = argv + ['--travis-yml-path', example]
+    scripts = main()
+    assert len(scripts) == 2, 'Scripts returned should be 2 for %s' % example
+    check_failed_dockerfile(scripts)
+    with open(os.path.join(scripts[0], 'Dockerfile')) as f_dkr:
+        dkr_content = f_dkr.read()
+        assert ' PSQL_VERSION="9.5" ' in dkr_content
+    with open(os.path.join(scripts[1], 'Dockerfile')) as f_dkr:
+        dkr_content = f_dkr.read()
+        assert ' PSQL_VERSION="9.5" ' in dkr_content
+
     url = 'https://github.com/Vauxoo/travis2docker.git'
     sys.argv = ['travis2docker', url, 'master']
     scripts = main()


### PR DESCRIPTION
This change adds support for the key `addons` -> `postgresql`, located
in the file `.travis.yml`. That key is used to manually specify the
PostgreSQL version, instead of using the default one.

For more information, see:
https://docs.travis-ci.com/user/database-setup/#Using-a-different-PostgreSQL-Version

Closes #116 