### PR TITLE
[IMP] travis2docker: Ensure changes in DB are saved before exiting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     - TOXENV=docs
 
     - TOXENV=py27,codecov
-    - TOXENV=py33,codecov
     - TOXENV=py34,codecov
     - TOXENV=py35,codecov
     - TOXENV=pypy,codecov

--- a/src/travis2docker/travis2docker.py
+++ b/src/travis2docker/travis2docker.py
@@ -182,7 +182,7 @@ class Travis2Docker(object):
                     for _, _, var, value in self.re_export.findall(line)])
                 f_section.write('\n' + line)
             if section == 'script':
-                f_section.write('\nsleep 2\n')
+                f_section.write('\npg_isready -q && /etc/init.d/postgresql stop\n')
         src = "./" + os.path.relpath(file_path, self.curr_work_path)
         dest = "/" + section
         args = {


### PR DESCRIPTION
The current approach to ensure all database changes are saved before the
container is stopped, is to wait two seconds, so PostgreSQL has enough
time to write changes to disk. However, this approach does not guarantee
changes will be saved safely, especially when dealing with unlogged
tables, which will not be written until the PostgreSQL service is
stopped.

This commit changes the approach. Instead of waiting a prudent amount of
time, this causes the PostgreSQL to be stopped before exiting the
container.