### PR TITLE
[FIX] issue with postgresql not being able to start

### DIFF
--- a/src/travis2docker/travis2docker.py
+++ b/src/travis2docker/travis2docker.py
@@ -183,6 +183,9 @@ class Travis2Docker(object):
                 f_section.write('\n' + line)
             if section == 'script':
                 f_section.write('\nsleep 2\n')
+                f_section.write('/etc/init.d/postgresql stop\n')
+                f_section.write('rm -f /var/run/postgresql/.s.PGSQL.5432*\n')
+
         src = "./" + os.path.relpath(file_path, self.curr_work_path)
         dest = "/" + section
         args = {


### PR DESCRIPTION
Make sure PostgreSQL is properly stopped after build and possible stale files related to the Unix Domain socket are removed to prevent failures when the build is run for testing. 

closes https://github.com/OCA/runbot-addons/issues/176