### PR TITLE
[WIP] [IMP] allow using sudo in the OCA runbot

### DIFF
--- a/examples/example_1.yml
+++ b/examples/example_1.yml
@@ -14,6 +14,7 @@ virtualenv:
 
 install:
   - touch install
+  - sudo touch install_root
 
 script:
   - touch script

--- a/examples/example_2.yml
+++ b/examples/example_2.yml
@@ -22,6 +22,7 @@ virtualenv:
 
 install:
   - touch install
+  - sudo touch install_root
 
 script:
   - touch script

--- a/examples/example_3.yml
+++ b/examples/example_3.yml
@@ -29,6 +29,7 @@ virtualenv:
 
 install:
   - touch install
+  - sudo touch install_root
 
 script:
   - touch script

--- a/examples/example_4.yml
+++ b/examples/example_4.yml
@@ -33,6 +33,7 @@ virtualenv:
 
 install:
   - touch install
+  - sudo touch install_root
 
 script:
   - touch script

--- a/examples/example_5.yml
+++ b/examples/example_5.yml
@@ -34,6 +34,7 @@ virtualenv:
 
 install:
   - touch install
+  - sudo touch install_root
 
 script:
   - touch script

--- a/src/travis2docker/templates/Dockerfile
+++ b/src/travis2docker/templates/Dockerfile
@@ -72,6 +72,11 @@ ENV {{ env }}
 
 WORKDIR ${TRAVIS_BUILD_DIR}
 
+{% if runs_sudo -%}
+USER root
+RUN {{ ' && '.join(runs_sudo) }}
+USER {{ user }}
+{%- endif %}
 
 {% if runs -%}
 {% if image == 'quay.io/travisci/travis-python' -%}

--- a/tests/test_travis2docker.py
+++ b/tests/test_travis2docker.py
@@ -51,6 +51,7 @@ def test_main():
     lines_required = [
         'RUN /bin/bash -c "{source_py} && {source_js} '
         '&& source /rvm_env.sh && /install"'.
+        'RUN /bin/bash -c touch install_root',
         format(source_py=sources_py, source_js=sources_js),
         'ENTRYPOINT /entrypoint.sh',
     ]


### PR DESCRIPTION
Current situation; the install section of travis is mapped to
instructions running with a non root user.

However, some setups in OCA projects such as l10n-brazil, are using
sudo in their travis file to run things such as locales updates, which
fails (blocked on password prompt).

With this change, we parse the lines starting with sudo in the section
and place them in a different script, called sudo_runs. This script is executed
*after* the runs script, in a section where the user is root.

known limitation: this does not work if the commands requiring sudo and the others
must be run in a specific order. But it should be good enough for oca/l10n-brazil.