### PR TITLE
[FIX] travis2docker: Always exit with a failure code

### DIFF
--- a/src/travis2docker/__main__.py
+++ b/src/travis2docker/__main__.py
@@ -8,14 +8,7 @@ Why does this file exist, and why __main__? For more info, read:
 - https://docs.python.org/2/using/cmdline.html#cmdoption-m
 - https://docs.python.org/3/using/cmdline.html#cmdoption-m
 """
-from sys import stdout
-
 from .cli import main
 
 if __name__ == "__main__":
-    FNAME_SCRIPTS = main()
-    stdout.write(
-        'Script generated: \n' +
-        '\n'.join(FNAME_SCRIPTS) +
-        '\n'
-    )
+    main()

--- a/src/travis2docker/cli.py
+++ b/src/travis2docker/cli.py
@@ -20,6 +20,7 @@ from os.path import expandvars
 from os.path import isdir
 from os.path import isfile
 from os.path import join
+from sys import stdout
 from tempfile import gettempdir
 
 from . import __version__
@@ -54,7 +55,7 @@ def yml_read(yml_path):
         return f_yml.read()
 
 
-def main():
+def main(return_result=False):
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "git_repo_url",
@@ -234,4 +235,11 @@ def main():
         'extra_params': run_extra_args,
         'extra_cmds': run_extra_cmds,
     }
-    return t2d.compute_dockerfile(skip_after_success=exclude_after_success)
+    fname_scripts = t2d.compute_dockerfile(skip_after_success=exclude_after_success)
+    if fname_scripts:
+        fname_list = '- ' + '\n- '.join(fname_scripts)
+        stdout.write('\nGenerated scripts:\n%s\n' % fname_list)
+    else:
+        stdout.write('\nNo scripts were generated.')
+    if return_result:
+        return fname_scripts

--- a/tests/test_travis2docker.py
+++ b/tests/test_travis2docker.py
@@ -4,12 +4,16 @@ import os
 import subprocess
 import sys
 
-from travis2docker.cli import main
+from travis2docker.cli import main as cli_main
 
 try:
     from shutil import which  # python3.x
 except ImportError:
     from whichcraft import which
+
+
+def main():
+    return cli_main(return_result=True)
 
 
 def check_failed_dockerfile(scripts, lines_required=None):


### PR DESCRIPTION
The program's exit code was being taken from the list that contains the
created scripts. When `os.exit` gets a parameter different from `None` and
an integer, the parameter is printed and the exit status will be one (i.e.
failure).

This was structured that way to be able to print created scripts when called
from `__main__`.

To solve the above, resulting scripts are always printed and no arguments are
passed as exit code.

In addition, printer result is prettier now, it's as follows::

```
Generated scripts:
- script_1
- script_2
```

Closes #99