### PR TITLE
[REF] travis2docker: Using main_app as image's tag instead of customer

### DIFF
--- a/src/travis2docker/travis2docker.py
+++ b/src/travis2docker/travis2docker.py
@@ -82,7 +82,7 @@ class Travis2Docker(object):
         self.variables_sh_data = {}
         if deployv:
             self.variables_sh_data = {var.lower(): value for _, _, var, value in self.re_export.findall(os_kwargs['variables_sh'])}
-            image = "%(docker_image_repo)s:%(customer)s-%(version)s-latest" % self.variables_sh_data if not image else image
+            image = "%(docker_image_repo)s:%(main_app)s-%(version)s-latest" % self.variables_sh_data if not image else image
             # TODO: Get the image based on the git sha
             build_sh = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'templates', 'build.sh')
             entrypoint_sh = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'templates', 'entrypoint_deployv.sh')


### PR DESCRIPTION
deployv is using main_app as tag in the docker images