### PR TITLE
[REF] travis2docker: Install pdbpp, ifconfig & iproute2 and remove multitail

### DIFF
--- a/src/travis2docker/templates/build.sh
+++ b/src/travis2docker/templates/build.sh
@@ -72,10 +72,12 @@ install_dev_tools(){
         rsync \
         zsh \
         gettext \
+        net-tools \
+        iproute2
         # aspell aspell-en aspell-es \
         # emacs \
         # byobu \
-        multitail
+        # multitail  # Set the terminal with red letters build the docker
 
     sudo pip install -q \
         ipython \
@@ -85,7 +87,8 @@ install_dev_tools(){
         pre-commit-vauxoo \
         diff-highlight \
         pg-activity \
-        nodeenv
+        nodeenv \
+        pdbpp
     # pre install pre-commit-vauxoo?
     # sudo su odoo -c "git init /tmp/test && cd /tmp/test && pre-commit-vauxoo -f"
     touch /home/odoo/full_test-requirements.txt


### PR DESCRIPTION
pdbpp is used by dev team
ifconfig & iproute2 are network tools used frequently

multitail is showing the terminal in red color