### PR TITLE
[FIX] travis2docker: add missing dependency libecpg-dev

### DIFF
--- a/src/travis2docker/templates/build.sh
+++ b/src/travis2docker/templates/build.sh
@@ -72,6 +72,7 @@ install_dev_tools(){
         rsync \
         gettext \
         net-tools \
+        libecpg-dev \
         iproute2
         # aspell aspell-en aspell-es \
         # emacs \


### PR DESCRIPTION
PR adds missing dependency `libecpg-dev` to fix the error: 

`Unable to execute 'ecpg', you likely need to install it.' - 'apt install -y libecpg-dev
`
![Screen Shot 2022-09-29 at 17 49 34](https://user-images.githubusercontent.com/54731581/193168122-74712b1c-f01e-46ee-8129-cdf95b0fbd2b.png)
