### PR TITLE
[REF] travis2docker: deployv - Disable workers

### DIFF
--- a/src/travis2docker/templates/build.sh
+++ b/src/travis2docker/templates/build.sh
@@ -30,7 +30,7 @@ install_pgcli_venv(){
 odoo_conf(){
     export ODOO_CONF=/home/odoo/.openerp_serverrc
     /entry_point.py run true
-    sed -i '/db_host\|db_password\|db_user/d' $ODOO_CONF
+    sed -i '/db_host\|db_password\|db_user\|workers/d' $ODOO_CONF
     su odoo -c "mkdir -p $ODOORC_DATA_DIR"
 }
 


### PR DESCRIPTION
Runbot and local dev envs have resources limited
And MQT was using workers=0
We need to match as possible in order to avoid variations when errors