### PR TITLE
Draft: [IMP] t2d: Add support for vscode with devcontainer.json

### DIFF
--- a/src/travis2docker/templates/.devcontainer.json
+++ b/src/travis2docker/templates/.devcontainer.json
@@ -1,0 +1,19 @@
+{
+	"name": "{{ repo_project }}",
+	"dockerFile": "Dockerfile",
+	"context": ".",
+	"remoteUser": "root",
+	"workspaceFolder": "/home/odoo/instance",
+	"customizations": {
+		"vscode": {
+            "extensions": [
+				"redhat.vscode-xml",
+				"ms-python.python",
+				"mechatroner.rainbow-csv"
+			],
+            "settings": {
+                "python.analysis.extraPaths": ["/home/odoo/instance/odoo"]
+            }
+		}
+	}
+}

--- a/src/travis2docker/travis2docker.py
+++ b/src/travis2docker/travis2docker.py
@@ -352,10 +352,17 @@ class Travis2Docker(object):
                         except TypeError:
                             f_rvm.write(rvm_env_content)
                     self.compute_build_scripts(count, version)
+                    self.compute_devcontainer(self.curr_work_path)
                     self.chmod_execution(entryp_path)
                     work_paths.append(self.curr_work_path)
         self.reset()
         return work_paths
+
+    def compute_devcontainer(self, dest):
+        """Generate a .devcontainer.json file to automatically start a Development Container in Vscode"""
+        devcontainer = self.jinja_env.get_template(".devcontainer.json").render(self.os_kwargs)
+        with open(os.path.join(dest, ".devcontainer.json"), 'w') as fl:
+            fl.write(devcontainer)
 
     def copy_path(self, path):
         """:param paths list: List of paths to copy"""


### PR DESCRIPTION
Related to #158 

This PR adds supports for devcontainers, a really cool option that integrates with vscode and automatically creates development containers. 

If everything goes well, when you open a folder with a `.devcontainer.json` file vscode automatically gives you the option to reopen in a remote container. With the proposed `devcontaner.json` this will open a vscode instance with:

- Three basic extensions for Odoo Development:
    - Python Extension for Inbuilt debugging (no more `pdb.set_trace()` :star_struck: )
    - Red Hat XML to support editing XML files (views, menus, etc...)
    - Rainbow CSV to have an easier time editing `ir.access.model.csv` records.

More extensions can easily be added, I only use/know of those three for Odoo development.

Odoo source code is also added to `extraPaths` which basically means you can `Ctrl + Click` on something like `from odoo import models` and have a new tab with the source code on it. This also means that function  arguments to stuff like `search` are suggested now based on Odoo's source code.

I am not very familiar with t2d source code so reviews are welcome since I am not sure I am placing the new feature in the correct place.