### PR TITLE
[IMP] Include .vscode for autoconfiguration

### DIFF
--- a/src/travis2docker/templates/.vscode/extensions.json
+++ b/src/travis2docker/templates/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["redhat.vscode-xml", "ms-python.python", "mechatroner.rainbow-csv"]
+}

--- a/src/travis2docker/templates/.vscode/launch.json
+++ b/src/travis2docker/templates/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Odoo",
+            "type": "python",
+            "request": "launch",
+            "program": "/home/odoo/instance/odoo/odoo-bin",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "gevent": true,
+            "args": [
+                "-c", "/home/odoo/.openerp_serverrc"
+            ]
+        },
+        {
+            "name": "Odoo Tests",
+            "type": "python",
+            "request": "launch",
+            "program": "/home/odoo/instance/odoo/odoo-bin",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "gevent": true,
+            "args": [
+                "-c", "/home/odoo/.openerp_serverrc",
+                "--test-tags", "standard"
+            ]
+        }
+    ]
+}

--- a/src/travis2docker/templates/.vscode/settings.json
+++ b/src/travis2docker/templates/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.analysis.extraPaths": ["/home/odoo/instance/odoo"]
+}

--- a/src/travis2docker/travis2docker.py
+++ b/src/travis2docker/travis2docker.py
@@ -102,9 +102,11 @@ class Travis2Docker(object):
                 os.path.dirname(os.path.realpath(__file__)), 'templates', 'entrypoint_deployv.sh'
             )
             docker_helper = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'docker_helper')
+            vscode_conf = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'templates', '.vscode')
             copy_paths.append([build_sh, '/home/odoo/build.sh'])
             copy_paths.append([entrypoint_sh, '/entrypoint.sh'])
             copy_paths.append([docker_helper, '/home/odoo/build'])
+            copy_paths.append([vscode_conf, '/home/odoo/.vscode'])
         if image is None:
             image = 'vauxoo/odoo-80-image-shippable-auto'
         if os_kwargs is None:


### PR DESCRIPTION
A `.vscode` folder is copied onto the container, this autoconfigures some things:

- Odoo imports are resolved (you can Ctrl+Click on them and go to the source code), also autocompletes Odoo methods
- Useful extensions are suggested, upon opening Vscode should give users the option to install all recommended exceptions.
- A `launch.json` is included, this lets you run and debug Odoo in different modes with the click of a button. Right now only "Odoo" and "Odoo Tests" modes are included.

I mark this as draft since there are some things to consider before committing:

1. Since this is a dev instance I am not sure there should be an Odoo service. Especially since it is more convenient to launch and stop it trough Vscode. Right now when launching from Vscode the port is already in use so that throws an error.
2. Should we try and find out what the main module being developed is? That way we could include one more Launch Option which runs the unit tests only for the main module being developed by the repo.
3. I personally run my tests on Vscode with the logger on ERROR level, since I don't really care about anything else when running unit tests. Should I add that by default on the "Odoo Tests" launch mode?

Also I am only use those extensions personally and don't know of any other useful setting, but perhaps some other people know cool Quality of Life stuff that could be added.