### PR TITLE
[IMP] t2d: Default --root-path #167

### DIFF
--- a/src/travis2docker/cli.py
+++ b/src/travis2docker/cli.py
@@ -16,7 +16,6 @@ import argparse
 import os
 from os.path import expanduser, expandvars, isdir, isfile, join
 from sys import stdout
-from tempfile import gettempdir
 
 from . import __version__
 from .exceptions import InvalidRepoBranchError
@@ -90,8 +89,8 @@ def main(return_result=False):
     )
     default_root_path = os.environ.get('TRAVIS2DOCKER_ROOT_PATH')
     if not default_root_path:
-        default_root_path = gettempdir()
-    default_root_path = join(default_root_path, 'travis2docker')
+        default_root_path = os.path.expanduser("~")
+    default_root_path = join(default_root_path, '.t2d')
     parser.add_argument(
         '--root-path',
         dest='root_path',


### PR DESCRIPTION
Fixes #167 

Root path is set to `$HOME/t2d`, I also took the liberty to create an extra folder per repo. So for example if I clone `vauxoo/random` all files created by t2d will be stored on `$HOME/t2d/vauxoo__random`, I think that is the expected behavior when someone hears root path, and the only way a default would be useful, otherwise I would still need to tell t2d where to store this specific project (relative to root path).