### PR TITLE
Draft [IMP] t2d: Automatically run odoo tests and generate coverage reports

### DIFF
--- a/src/travis2docker/templates/.coveragerc
+++ b/src/travis2docker/templates/.coveragerc
@@ -1,0 +1,39 @@
+[run]
+branch = True
+command_line =
+    ${HOME}/instance/odoo/odoo-bin -c ${ODOO_CONFIG_FILE} -d odoocov -i ${MODULES2INSTALL}
+    -u ${MODULES2INSTALL} --test-tags ${MODULES2TEST}  --workers 0 --stop-after-init
+relative_files = True
+source = ${COVERAGE_HOME}
+data_file = ${COVERAGE_HOME}/.coverage
+dynamic_context = ${COVERAGE_DYNAMIC_CONTEXT}
+omit =
+    */scenario/*
+    */scenarios/*
+    */test/*
+    */tests/*
+    */migrations/*
+    *migration*
+    *_example/*
+    *__init__.py
+    *__openerp__.py
+    *__manifest__.py
+    ${EXCLUDE_COVERAGE}
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+    # Don't complain about null context checking
+    if context is None:
+    # Don't check obviously not implemented
+    raise NotImplementedError
+    # We don't really care what happens if fail
+    except ImportError:
+
+fail_under = ${COVERAGE_MIN-0}
+precision = ${COVERAGE_PRECISION-0}
+
+[html]
+show_contexts=True

--- a/src/travis2docker/templates/Dockerfile_deployv
+++ b/src/travis2docker/templates/Dockerfile_deployv
@@ -18,6 +18,9 @@ RUN cat ${HOME}/.ssh/id_rsa.pub | tee -a ${HOME}/.ssh/authorized_keys
 {%- endif %}
 
 ENV ODOORC_DB_NAME=odoo ODOORC_PIDFILE=/home/odoo/.odoo.pid ODOORC_DATA_DIR=/home/odoo/data_dir PROFILE_FILE=/etc/bash.bashrc MAIN_REPO_FULL_PATH=/home/odoo/instance/$MAIN_REPO_PATH DEB_PYTHON_INSTALL_LAYOUT=deb
+ENV COVERAGE_RCFILE=$HOME/.coveragerc
+ENV COVERAGE_HOME=$MAIN_REPO_FULL_PATH
+
 {% for build_env_arg in build_env_args %}
 ENV {{ build_env_arg }}=TRUE
 {% endfor %}
@@ -33,6 +36,7 @@ RUN . /home/odoo/build.sh && \
     chown_all && \
     git_set_remote && \
     bash_colorized && \
+    setup_coverage && \
     configure_vim && \
     configure_zsh && \
     mv /entrypoint_image /deployv_entrypoint_image && \

--- a/src/travis2docker/templates/build.sh
+++ b/src/travis2docker/templates/build.sh
@@ -129,6 +129,12 @@ EOF
     # TODO: Install custom vim?
 }
 
+setup_coverage() {
+  echo "export MODULES2TEST=$(cd ${MAIN_REPO_FULL_PATH} && find * -name "__manifest__.py" -printf "/%h,")" >> ${HOME}/.bashrc
+  echo "export MODULES2INSTALL=$(cd ${MAIN_REPO_FULL_PATH} && find * -name "__manifest__.py" -printf "%h,")" >> ${HOME}/.bashrc
+}
+
+
 bash_colorized(){
     cat >> ~/.bashrc << 'EOF'
 Purple="\[\033[0;35m\]"

--- a/src/travis2docker/travis2docker.py
+++ b/src/travis2docker/travis2docker.py
@@ -103,10 +103,12 @@ class Travis2Docker(object):
             )
             docker_helper = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'docker_helper')
             vscode_conf = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'templates', '.vscode')
+            coveragerc = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'templates', '.coveragerc')
             copy_paths.append([build_sh, '/home/odoo/build.sh'])
             copy_paths.append([entrypoint_sh, '/entrypoint.sh'])
             copy_paths.append([docker_helper, '/home/odoo/build'])
             copy_paths.append([vscode_conf, '/home/odoo/.vscode'])
+            copy_paths.append([coveragerc, '/home/odoo/.coveragerc'])
         if image is None:
             image = 'vauxoo/odoo-80-image-shippable-auto'
         if os_kwargs is None:


### PR DESCRIPTION
Fixes #178 

Coverage reports are automatically generated with the new inbuilt command `vxcov`. 