### PR TITLE
[FIX] t2d: Branch name for testing updated to main

### DIFF
--- a/tests/test_travis2docker.py
+++ b/tests/test_travis2docker.py
@@ -115,7 +115,7 @@ def test_main():
         assert ' PSQL_VERSION="9.5" ' in dkr_content
 
     url = 'https://github.com/Vauxoo/travis2docker.git'
-    sys.argv = ['travis2docker', url, 'master']
+    sys.argv = ['travis2docker', url, 'main']
     scripts = main()
     sources_py = "source ${REPO_REQUIREMENTS}/virtualenv/" + "python3.5/bin/activate"
     lines_required.pop(0)

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,6 @@ usedevelop = false
 deps = -r{toxinidir}/requirements.txt
     # test deps
     pytest
-    pytest-travis-fold
     pytest-cov
     whichcraft
     nodeenv


### PR DESCRIPTION
The branch `master` was renamed to `main` so all unit tests were failing. This fixes them.