### PR TITLE
[FIX] t2d: Remove vim YouCompleteMe plugin I#165

### DIFF
--- a/src/travis2docker/templates/build.sh
+++ b/src/travis2docker/templates/build.sh
@@ -230,19 +230,8 @@ EOF
 let g:signify_disable_by_default = 1
 EOF
 
-    # Install and configure YouCompleteMe
-    VIM_YOUCOMPLETEME_PATH="${HOME}/.vim/bundle/YouCompleteMe"
-    git clone "https://github.com/Valloric/YouCompleteMe.git" ${VIM_YOUCOMPLETEME_PATH} --depth 1
-    # Install the custom version of YouCompleteMe because the last required g++ 4.9
-    (cd "${VIM_YOUCOMPLETEME_PATH}" && git reset --hard c31152d34591f3211799ca1fe918eb78487e6dde && git submodule update --init --recursive && ./install.py)
-    cat >> ${HOME}/.vimrc << EOF
-" Disable auto trigger for youcompleteme
-let g:ycm_auto_trigger = 0
-EOF
-
     # Install WakaTime
     git_clone_copy "https://github.com/wakatime/vim-wakatime.git" "master" "." "${HOME}/.vim/bundle/vim-wakatime"
-
     cat >> ${HOME}/.vimrc << EOF
 colorscheme heliotrope
 set colorcolumn=119


### PR DESCRIPTION
YouCompleteMe was causing issues as ycmd was not being installed properly, however installating it offers no benefit since it did not mention support for python3 autocompleting, and it is not used for the pdb + TAB -> `__import__('pdb').set_trace()` feature which is the most requested feature by Vauxoo Devs. Therefore it was removed.