### PR TITLE
[FIX] t2d: Permission issues on ~/.cache (#186)

### DIFF
--- a/src/travis2docker/cli.py
+++ b/src/travis2docker/cli.py
@@ -263,7 +263,10 @@ def main(return_result=False):
                 '\nUsing --deployv option you will need to run the following extra step '
                 'manually after to create the container or after running 20-run.sh script'
             )
-            stdout.write('\ndocker exec -it --user=root CONTAINER chown -R odoo:odoo /home/odoo/.ssh\n')
+            stdout.write(
+                '\ndocker exec -it --user=root CONTAINER '
+                'find /home/odoo -maxdepth 1 -not -user odoo -exec chown -R odoo:odoo {} \\;\n'
+            )
             if not default_docker_image:
                 # TODO: Add the URL to open the pipelines
                 stdout.write(

--- a/src/travis2docker/templates/Dockerfile_deployv
+++ b/src/travis2docker/templates/Dockerfile_deployv
@@ -32,13 +32,12 @@ RUN . /home/odoo/build.sh && \
     install_pgcli_venv && \
     custom_alias && \
     odoo_conf && \
-    chown -R odoo:odoo /home/odoo/.ssh && \
-    chown_all && \
     git_set_remote && \
     bash_colorized && \
     setup_coverage && \
     configure_vim && \
     configure_zsh && \
+    chown_all && \
     mv /entrypoint_image /deployv_entrypoint_image && \
     mv /entry_point.py /deployv_entry_point.py
 

--- a/src/travis2docker/templates/build.sh
+++ b/src/travis2docker/templates/build.sh
@@ -131,7 +131,6 @@ EOF
 
     # Configure emacs for odoo user
     git clone --depth 1 -b master https://github.com/Vauxoo/emacs.d.git /home/odoo/.emacs.d
-    chown -R odoo:odoo /home/odoo/.emacs.d
 }
 
 setup_coverage() {
@@ -283,8 +282,6 @@ let g:spf13_bundle_groups = ['general', 'writing', 'odoovim', 'wakatime',
                            \ 'python', 'javascript', 'html',
                            \ 'misc']
 EOF
-
-chown -R odoo:odoo ${HOME}/.vim*
 }
 
 configure_zsh(){
@@ -298,7 +295,6 @@ configure_zsh(){
     ZSH=${HOME}
     sh /tmp/install_zsh.sh "" --unattended
     wget -O /home/odoo/.oh-my-zsh/themes/odoo-shippable.zsh-theme https://gist.githubusercontent.com/schminitz/9931af23bbb59e772eec/raw/cb524246fc93df242696bc3f502cababb03472ec/schminitz.zsh-theme
-    chown -R odoo:odoo /home/odoo/.oh-my-zsh /home/odoo/.zshrc
     sed -i 's/root/home\/odoo/g' /home/odoo/.zshrc
     sed -i 's/robbyrussell/odoo-shippable/g' /home/odoo/.zshrc
     sed -i 's/^plugins=(/plugins=(\n  virtualenv\n/' /home/odoo/.zshrc


### PR DESCRIPTION
Fixes #186

`/home/odoo/.cache` is created when installing vim by the `ctrlp` vim plugin and is owned by root. This causes issues when other programs like pre-commit are run without privileges by end users and try to access `.cache`.