### PR TITLE
FIX: CI and consider EXCLUDE env var in deployv entrypoint

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -13,144 +13,33 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
+        python: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        tox_env: ["py,codecov"]
         include:
-          - name: 'check'
-            python: '3.9'
-            toxpython: 'python3.9'
-            tox_env: 'check'
-            os: 'ubuntu-latest'
-          - name: 'docs'
-            python: '3.9'
-            toxpython: 'python3.9'
-            tox_env: 'docs'
-            os: 'ubuntu-latest'
-
-          # ubuntu
-          - name: 'py27-cover (ubuntu)'
-            python: '2.7'
-            toxpython: 'python2.7'
-            python_arch: 'x64'
-            tox_env: 'py27,codecov'
-            os: 'ubuntu-latest'
-          - name: 'py35-cover (ubuntu)'
-            python: '3.5'
-            toxpython: 'python3.5'
-            python_arch: 'x64'
-            tox_env: 'py35,codecov'
-            os: 'ubuntu-latest'
-          - name: 'py36-cover (ubuntu)'
-            python: '3.6'
-            toxpython: 'python3.6'
-            python_arch: 'x64'
-            tox_env: 'py36,codecov'
-            os: 'ubuntu-latest'
-          - name: 'py37-cover (ubuntu)'
-            python: '3.7'
-            toxpython: 'python3.7'
-            python_arch: 'x64'
-            tox_env: 'py37,codecov'
-            os: 'ubuntu-latest'
-          - name: 'py38-cover (ubuntu)'
-            python: '3.8'
-            toxpython: 'python3.8'
-            python_arch: 'x64'
-            tox_env: 'py38,codecov'
-            os: 'ubuntu-latest'
-          - name: 'py39-cover (ubuntu) + pypi release'
-            python: '3.9'
-            toxpython: 'python3.9'
-            python_arch: 'x64'
-            tox_env: 'py39,codecov'
-            os: 'ubuntu-latest'
-          - name: 'py310-cover (ubuntu)'
-            python: '3.10'
-            toxpython: 'python3.10'
-            python_arch: 'x64'
-            tox_env: 'py310,codecov'
-            os: 'ubuntu-latest'
-
-          # windows
-          - name: 'py36-cover (windows)'
-            python: '3.6'
-            toxpython: 'python3.6'
-            python_arch: 'x64'
-            tox_env: 'py36,codecov'
-            os: 'windows-latest'
-          - name: 'py37-cover (windows)'
-            python: '3.7'
-            toxpython: 'python3.7'
-            python_arch: 'x64'
-            tox_env: 'py37,codecov'
-            os: 'windows-latest'
-          - name: 'py38-cover (windows)'
-            python: '3.8'
-            toxpython: 'python3.8'
-            python_arch: 'x64'
-            tox_env: 'py38,codecov'
-            os: 'windows-latest'
-          - name: 'py39-cover (windows)'
-            python: '3.9'
-            toxpython: 'python3.9'
-            python_arch: 'x64'
-            tox_env: 'py39,codecov'
-            os: 'windows-latest'
-          - name: 'py310-cover (windows)'
-            python: '3.10'
-            toxpython: 'python3.10'
-            python_arch: 'x64'
-            tox_env: 'py310,codecov'
-            os: 'windows-latest'
-
-          # macos
-          - name: 'py27-cover (macos)'
-            python: '2.7'
-            toxpython: 'python2.7'
-            python_arch: 'x64'
-            tox_env: 'py27,codecov'
-            os: 'macos-latest'
-          - name: 'py35-cover (macos)'
-            python: '3.5'
-            toxpython: 'python3.5'
-            python_arch: 'x64'
-            tox_env: 'py35,codecov'
-            os: 'macos-latest'
-          - name: 'py36-cover (macos)'
-            python: '3.6'
-            toxpython: 'python3.6'
-            python_arch: 'x64'
-            tox_env: 'py36,codecov'
-            os: 'macos-latest'
-          - name: 'py37-cover (macos)'
-            python: '3.7'
-            toxpython: 'python3.7'
-            python_arch: 'x64'
-            tox_env: 'py37,codecov'
-            os: 'macos-latest'
-          - name: 'py38-cover (macos)'
-            python: '3.8'
-            toxpython: 'python3.8'
-            python_arch: 'x64'
-            tox_env: 'py38,codecov'
-            os: 'macos-latest'
-          - name: 'py39-cover (macos)'
-            python: '3.9'
-            toxpython: 'python3.9'
-            python_arch: 'x64'
-            tox_env: 'py39,codecov'
-            os: 'macos-latest'
-          - name: 'py310-cover (macos)'
-            python: '3.10'
-            toxpython: 'python3.10'
-            python_arch: 'x64'
-            tox_env: 'py310,codecov'
-            os: 'macos-latest'
-
+          - python: '3.5'
+            os: ubuntu-20.04
+            tox_env: "py,codecov"
+          - python: '3.6'
+            os: ubuntu-20.04
+            tox_env: "py,codecov"
+          - python: '3.9'
+            os: ubuntu-latest
+            tox_env: 'check,docs'
+        exclude:
+          - python: '3.5'
+            os: ubuntu-latest
+          - python: '3.6'
+            os: ubuntu-latest
+          - python: '2.7'
+            os: windows-latest
+          - python: '3.5'
+            os: windows-latest
     steps:
     - uses: actions/checkout@v3
       with:
@@ -159,14 +48,14 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
-        architecture: ${{ matrix.python_arch }}
+        architecture: x64
         cache: 'pip'
     - name: Cache pre-commit packages
       id: cache-pre-commit
       uses: actions/cache@v3
       with:
         path: ~/.cache/pre-commit
-        key: ${{ runner.os }}-py${{ matrix.python }}-${{ matrix.python_arch }}-pre-commit
+        key: ${{ runner.os }}-py${{ matrix.python }}-pre-commit
     - name: install dependencies
       run: |
         python -mpip install --progress-bar=off -r ci/requirements.txt
@@ -175,8 +64,6 @@ jobs:
         tox --version
         pip list --format=freeze
     - name: test
-      env:
-        TOXPYTHON: '${{ matrix.toxpython }}'
       run: >-
         mkdir -p ~/.ssh &&
         tox -e ${{ matrix.tox_env }} -v

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -49,7 +49,7 @@ To set up `travis2docker` for local development:
 
    Now you can make your changes locally.
 
-4. When you're done making changes, run all the checks, doc builder and spell checker with `tox <http://tox.readthedocs.io/en/latest/install.html>`_ one command::
+4. When you're done making changes, run all the checks, doc builder and spell checker with `tox <https://tox.wiki/en/latest/installation.html>`_ one command::
 
     tox
 

--- a/src/travis2docker/templates/entrypoint_deployv.sh
+++ b/src/travis2docker/templates/entrypoint_deployv.sh
@@ -58,7 +58,10 @@ def start_psql():
 def list_modules(modules_path):
     main_repo_path = os.environ["MAIN_REPO_FULL_PATH"]
     list_modules = []
+    excluded_modules = set([module.strip() for module in os.environ.get("EXCLUDE", "").split(",") if module.strip()])
     for i in os.listdir(main_repo_path):
+        if i in excluded_modules:
+          continue
         manifest = os.path.join(main_repo_path, i, "__manifest__.py")
         if os.path.isfile(manifest):
             manifest_data = eval(open(manifest).read())

--- a/tests/test_travis2docker.py
+++ b/tests/test_travis2docker.py
@@ -20,8 +20,8 @@ def main():
 
 def check_failed_dockerfile(scripts, lines_required=None):
     npm_bin = which('npm')
-    npm_bin_path = subprocess.check_output([npm_bin, 'bin']).decode('UTF-8').strip('\n') if npm_bin else ""
-    npm_bin_path_g = subprocess.check_output([npm_bin, 'bin', '-g']).decode('UTF-8').strip('\n') if npm_bin else ""
+    npm_bin_path = subprocess.check_output([npm_bin, 'list']).decode('UTF-8').strip('\n') if npm_bin else ""
+    npm_bin_path_g = subprocess.check_output([npm_bin, 'list', '-g']).decode('UTF-8').strip('\n') if npm_bin else ""
     lint_bin_name = 'dockerfile_lint'
     lint_bin = which(lint_bin_name) or which(lint_bin_name, path=npm_bin_path + os.pathsep + npm_bin_path_g)
     assert lint_bin, "'%s' not found." % lint_bin_name

--- a/tox.ini
+++ b/tox.ini
@@ -4,23 +4,10 @@
 envlist =
     clean,
     check,
-    {py27,py34,py35,py36,py37,py38,py39,py310,pypy},
     report,
     docs
 
 [testenv]
-basepython =
-    pypy: {env:TOXPYTHON:pypy}
-    py27: {env:TOXPYTHON:python2.7}
-    py34: {env:TOXPYTHON:python3.4}
-    py35: {env:TOXPYTHON:python3.5}
-    py36: {env:TOXPYTHON:python3.6}
-    py37: {env:TOXPYTHON:python3.7}
-    py38: {env:TOXPYTHON:python3.8}
-    py39: {env:TOXPYTHON:python3.9}
-    py310: {env:TOXPYTHON:python3.10}
-    {docs,spell,clean,check,report,coveralls,codecov}: {env:TOXPYTHON:python3.8}
-    bootstrap: python
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes


### PR DESCRIPTION
EXCLUDE was not being taken into account when deciding which modules to install and run when using --deployv. Fixed the entrypoint to do so