### PR TITLE
Fix: Github Actions not publishing releases

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -64,25 +64,22 @@ jobs:
         tox --version
         pip list --format=freeze
     - name: test
-      run: >-
-        mkdir -p ~/.ssh &&
+      run: |
+        mkdir -p ~/.ssh
         tox -e ${{ matrix.tox_env }} -v
     - name: Build a binary wheel and a source tarball
-      if: runner.os == 'Linux' && startsWith(matrix.tox_env, 'py39')
-      run: >-
-        python -m pip install build wheel twine && python -m
-        build
-        --sdist
-        --wheel
-        --outdir dist_wo_pbr/ && python -m
-        build
-        --no-isolation
-        --sdist
-        --wheel
-        --outdir dist/ &&
+      if: runner.os == 'Linux' && matrix.python == '3.9' && startsWith(matrix.tox_env, 'py')
+      run: |
+        python -m pip install build wheel twine
+        python -m build --sdist --wheel --outdir dist_wo_pbr/
+        python -m build --no-isolation --sdist --wheel --outdir dist/
         twine check dist/*
     - name: Publish package
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && runner.os == 'Linux' && startsWith(matrix.tox_env, 'py39')
+      if: |
+        github.event_name == 'push' &&
+        startsWith(github.ref, 'refs/tags') &&
+        runner.os == 'Linux' &&
+        matrix.python == '3.9' && startsWith(matrix.tox_env, 'py')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Previous refactoring in the matrix syntax for github-actions.yml caused a regression where packages were no longer being built and new versions were not being automatically published to pypi.

This commit fixes the 'if' conditions so packages are built and published once again.