### PR TITLE
[IMP] Add support for ed25519 keys and prefer them over RSA

### DIFF
--- a/src/travis2docker/cli.py
+++ b/src/travis2docker/cli.py
@@ -238,8 +238,7 @@ def main(return_result=False):
             + "\nverify exists .travis.yml"
         )
         raise InvalidRepoBranchError(msg)
-
-    os_kwargs.update({'add_self_rsa_pub': True, 'remotes': remotes, 'git_base': git_base})
+    os_kwargs.update({'remotes': remotes, 'git_base': git_base})
     if docker_user:
         os_kwargs.update({'user': docker_user})
     t2d = Travis2Docker(

--- a/src/travis2docker/templates/Dockerfile_deployv
+++ b/src/travis2docker/templates/Dockerfile_deployv
@@ -13,10 +13,6 @@ RUN {% for src, dest in copies or [] -%} chown -R {{ user }}:{{ user }} {{dest}}
 {%- endfor -%}
 {%- endif %}
 
-{% if add_self_rsa_pub -%}
-RUN cat ${HOME}/.ssh/id_rsa.pub | tee -a ${HOME}/.ssh/authorized_keys
-{%- endif %}
-
 ENV ODOORC_DB_NAME=odoo ODOORC_PIDFILE=/home/odoo/.odoo.pid ODOORC_DATA_DIR=/home/odoo/data_dir PROFILE_FILE=/etc/bash.bashrc MAIN_REPO_FULL_PATH=/home/odoo/instance/$MAIN_REPO_PATH DEB_PYTHON_INSTALL_LAYOUT=deb
 ENV COVERAGE_RCFILE=$HOME/.coveragerc
 ENV COVERAGE_HOME=$MAIN_REPO_FULL_PATH
@@ -38,6 +34,7 @@ RUN . /home/odoo/build.sh && \
     configure_vim && \
     configure_zsh && \
     chown_all && \
+    set_authorized_keys && \
     mv /entrypoint_image /deployv_entrypoint_image && \
     mv /entry_point.py /deployv_entry_point.py
 

--- a/src/travis2docker/templates/build.sh
+++ b/src/travis2docker/templates/build.sh
@@ -55,6 +55,26 @@ EOF
     # alias odoo
 }
 
+set_authorized_keys(){
+    YELLOW='\033[0;33m'
+    NC='\033[0m'
+
+    AUTH_FILE="${HOME}/.ssh/authorized_keys"
+    ED_KEY="${HOME}/.ssh/id_ed25519.pub"
+    RSA_KEY="${HOME}/.ssh/id_rsa.pub"
+
+    echo "INFO: Adding public key to ~/.ssh/authorized_keys"
+    if [ -f "${ED_KEY}" ]; then
+        tee -a "${AUTH_FILE}" < "${ED_KEY}"
+    elif [ -f "${RSA_KEY}" ]; then
+        printf "${YELLOW}WARNING: RSA keys are deprecated, consider changing to ed25519\n${NC}"
+        tee -a "${AUTH_FILE}" < "${RSA_KEY}"
+    else
+        echo "INFO: No public key found. No key added to ~/.ssh/authorized_keys"
+    fi
+}
+
+
 # You can add new packages here
 install_dev_tools(){
     apt update -qq


### PR DESCRIPTION
Fixes #193
The container automatically copies the user's public key to its authorized_keys, allowing users to connect via SSH.

id_rsa.pub was the default key the Dockerfile looked for, since it is deprecated (in favor of ed25519) a new script (function) "set_authorized_keys" was added.

This script:
1. Tries to first copy id_ed25519.pub (if it exists)
2. If it does not, it falls back to RSA keys and prints a deprecation warning (if it exists).
3. Otherwise it alerts the user to the fact nothing was copied.

Also, since the condition add_self_rsa_pub was hardcoded to True, it was removed and the keys are just copied directly.