### PR TITLE
[REF] tox: Add new env "build" to test the package build

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -30,7 +30,7 @@ jobs:
             tox_env: "py,codecov"
           - python: '3.10'
             os: ubuntu-latest
-            tox_env: 'check,docs'
+            tox_env: 'check,docs,build'
         exclude:
           - python: '3.5'
             os: ubuntu-latest
@@ -67,15 +67,9 @@ jobs:
       run: |
         mkdir -p ~/.ssh
         tox -e ${{ matrix.tox_env }} -v
-    - name: Build a binary wheel and a source tarball
-      if: runner.os == 'Linux' && matrix.python == '3.9' && startsWith(matrix.tox_env, 'py')
-      run: |
-        python -m pip install build wheel twine
-        python -m build --sdist --wheel --outdir dist_wo_pbr/
-        python -m build --no-isolation --sdist --wheel --outdir dist/
-        twine check dist/*
+    # TODO: Publish package only for signed tags
     - name: Publish package
-      if: runner.os == 'Linux' && matrix.python == '3.9' && startsWith(matrix.tox_env, 'py') && startsWith(github.ref, 'refs/tags/v')
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && contains(matrix.tox_env, 'build')
+      run: |
+        ls -lah dist/*
+        python -m twine upload --verbose -u __token__ -p ${{ secrets.PYPI_API_TOKEN }} --repository-url https://upload.pypi.org/legacy/ dist/*

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         re.compile('^.. start-badges.*^.. end-badges', re.M | re.S).sub('', read('README.rst')),
         re.sub(':[a-z]+:`~?(.*?)`', r'``\1``', read('CHANGELOG.rst')),
     ),
+    long_description_content_type="text/x-rst",
     author='Vauxoo',
     author_email='info@vauxoo.com',
     url='https://github.com/vauxoo/travis2docker',

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 
 [tox]
 envlist =
+    build,
     clean,
     check,
     report,
@@ -70,6 +71,24 @@ commands =
     ; We are using git submodule in the package
     ; check-manifest {toxinidir}
     pre-commit-vauxoo -t all --no-overwrite -p src/ -p tests/ -p setup.py
+
+[testenv:build]
+skip_install = true
+deps =
+    build
+    bump2version
+    twine
+    wheel
+commands =
+    python -m build --sdist --wheel --outdir dist_wo_pbr/
+    python -c "import shutil;shutil.rmtree('dist/', ignore_errors=True)"
+    python -m build --no-isolation --sdist --wheel --outdir dist/  # Generate ChangeLog with pbr
+    python -m twine check --strict dist/*
+    bump2version patch --allow-dirty --no-commit --no-tag --dry-run --verbose
+    # Install packages from binaries to test if all files were already included in the compressed file
+    python -c '''import sys,pip,os,glob;os.chdir("dist");sys.argv = ["", "install", "-U", "--force-reinstall", glob.glob("*.tar.gz")[-1], "--use-feature=no-binary-enable-wheel-cache"];pip.main()'''
+    # Testing the package is importing the dependencies well
+    python -c '''import sys, os;from travis2docker import cli,cli;os.chdir("dist");sys.argv = ["", "--help"];cli.main()'''
 
 [testenv:coveralls]
 deps =


### PR DESCRIPTION
* Test the package can be build without errors
* Test the bump2version script
* Add missing long description format: rst
* CI uses tox -e build

Based on pylint-odoo project