### PR TITLE
[IMP] pull image before building

### DIFF
--- a/src/travis2docker/templates/10-build.sh
+++ b/src/travis2docker/templates/10-build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 export IMAGE={{ image }}
-docker build {{ extra_params }} $1 -t $IMAGE {{ dirname_dockerfile }}
+docker build --pull {{ extra_params }} $1 -t $IMAGE {{ dirname_dockerfile }}
 {{ extra_cmds }}


### PR DESCRIPTION
In order to have a better user experience, we must ensure that the latest image is always used, therefore the argument --pull has been added