### PR TITLE
[FIX] start ssh server when `START_SSH` build-env-arg is supplied (deployv)

### DIFF
--- a/src/travis2docker/templates/Dockerfile_deployv
+++ b/src/travis2docker/templates/Dockerfile_deployv
@@ -36,7 +36,8 @@ RUN . /home/odoo/build.sh && \
     chown_all && \
     set_authorized_keys && \
     mv /entrypoint_image /deployv_entrypoint_image && \
-    mv /entry_point.py /deployv_entry_point.py
+    mv /entry_point.py /deployv_entry_point.py && \
+    mkdir /run/sshd
 
 
 USER {{ user }}

--- a/src/travis2docker/templates/entrypoint_deployv.sh
+++ b/src/travis2docker/templates/entrypoint_deployv.sh
@@ -61,7 +61,7 @@ def list_modules(modules_path):
     excluded_modules = set([module.strip() for module in os.environ.get("EXCLUDE", "").split(",") if module.strip()])
     for i in os.listdir(main_repo_path):
         if i in excluded_modules:
-          continue
+            continue
         manifest = os.path.join(main_repo_path, i, "__manifest__.py")
         if os.path.isfile(manifest):
             manifest_data = eval(open(manifest).read())


### PR DESCRIPTION
Fixes #200.

When supplying t2d the "START_SSH" argument during setup it is expected
that the generated image will automatically start running  the ssh
service.

This was not happening when using --deployv, it has been fixed by
adding the logic to autostart the server in the entrypoint for it.

Since the SSH server can only be started by root, the other commands
in the entrypoint have been modified to use the correct user if the
image is being run as root.

The same support has been given to ODOO and PSQL services. They start by
default but this can be avoided by providing a falsy value for
START_ODOO and START_PSQL respectively.