### PR TITLE
[REV] add .travis.yml back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,68 @@
+language: python
+sudo: false
+env:
+  global:
+    - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
+    - SEGFAULT_SIGNALS=all
+matrix:
+  include:
+    - python: 2.7
+      env:
+        TOXENV=py27,codecov
+    # TODO: Fix coverage diff version issue
+    # - python: 3.4
+    #   env:
+    #     TOXENV=py34,codecov
+    - python: 3.5
+      env:
+        TOXENV=py35,codecov
+    - python: 3.6
+      env:
+        TOXENV=py36,codecov
+    - python: 3.7
+      env:
+        TOXENV=py37,codecov
+    - python: 3.8
+      env:
+        TOXENV=py38,codecov
+    - python: 3.9
+      env:
+        TOXENV=py39,codecov
+    - python: pypy
+      env:
+        TOXENV=pypy,codecov
+    - python: 3.5
+      env:
+        TOXENV=check
+    - python: 3.5
+      env:
+        TOXENV=docs
+before_install:
+  - python --version
+  - uname -a
+  - lsb_release -a
+install:
+  - pip install tox
+  - virtualenv --version
+  - easy_install --version
+  - pip --version
+  - tox --version
+script:
+  - tox -ve $TOXENV
+after_failure:
+  - more .tox/log/* | cat
+  - more .tox/*/log/* | cat
+before_cache:
+  - rm -rf $HOME/.cache/pip/log
+cache:
+  directories:
+    - $HOME/.cache/pip
+deploy:
+  provider: pypi
+  user: vauxoo
+  password:
+    secure: dScWMD2+phGrPeufO2TTQLa3ZW5olWrSf1xXwki2UcrPjF4vIHmFUFoHZ9zK3BPVnY114XArb7O5N0pGO+j9b8G3jXD0HA+jlkMEtrbRJ1kiKUAb4KzF3xs9S/qLNZ2I3+pcE29+faDEV4CErsmlVK/h2HEYVdseH+V0qXUGxEk2bY6NKQ5LGkhb4Ole3wWLah11vvAEGcYQLd0K/hRoNup0bDgmjacH4gfCXLfhNJkz3hw1D/FPYv2Z7AIVvo/UMQS62LisMKKcw7DltzMg7rp1tuQdt7gUBD/EGiqlyVqSgj7d0XOO3HucJK9KATQRDoetVwCQSiR5GwMu39zqijpd1AH5T4mxm9w7xAG9KGlog12dDjZe5eneGGXxfxApZ5K12huiSfxAMHiF6Yhm3BDNTh3WeWAYxH2o3XoqoB5DZowWWAw9Fdl3iG7QdNaboVZ6iOxPUxERJYkle5a74RraQyPEdv7xHyNZhjMrc1NOIzYswGsvMgW/TyCKpBqidSFrkOf6hCGOdMbRXmqtM+M2mAV4WuIJx3fbXT3nvpHmdMMMnwyAYY35CQaz2RcQ3mV7WcyKi0zyrys3wcgsZ2lBMxiqpmBJzDAZQDhBtX8xIKvtdZHf8lbUQFrQttwBgsZIL3eKVFE37iKJEIhMnWXvPcYyhhBYdeu4E9MarSQ=
+  on:
+    tags: true
+    condition: $TOXENV == py37,codecov
+    repo: Vauxoo/travis2docker


### PR DESCRIPTION
Previous CI and tox runs apparently lied. This is because tests run against the main branch upstream, and not against the source code.

This generates false positives/negatives that are only found when a merge completes but spending time fixing it is not a priority as of now. Therefore the quickfix of adding the file back has been chosen.