### PR TITLE
[FIX] t2d: add ssh key to authorized_keys

### DIFF
--- a/src/travis2docker/templates/Dockerfile_deployv
+++ b/src/travis2docker/templates/Dockerfile_deployv
@@ -34,7 +34,6 @@ RUN . /home/odoo/build.sh && \
     configure_vim && \
     configure_zsh && \
     chown_all && \
-    set_authorized_keys && \
     mv /entrypoint_image /deployv_entrypoint_image && \
     mv /entry_point.py /deployv_entry_point.py && \
     mkdir /run/sshd

--- a/src/travis2docker/templates/build.sh
+++ b/src/travis2docker/templates/build.sh
@@ -55,26 +55,6 @@ EOF
     # alias odoo
 }
 
-set_authorized_keys(){
-    YELLOW='\033[0;33m'
-    NC='\033[0m'
-
-    AUTH_FILE="${HOME}/.ssh/authorized_keys"
-    ED_KEY="${HOME}/.ssh/id_ed25519.pub"
-    RSA_KEY="${HOME}/.ssh/id_rsa.pub"
-
-    echo "INFO: Adding public key to ~/.ssh/authorized_keys"
-    if [ -f "${ED_KEY}" ]; then
-        tee -a "${AUTH_FILE}" < "${ED_KEY}"
-    elif [ -f "${RSA_KEY}" ]; then
-        printf "${YELLOW}WARNING: RSA keys are deprecated, consider changing to ed25519\n${NC}"
-        tee -a "${AUTH_FILE}" < "${RSA_KEY}"
-    else
-        echo "INFO: No public key found. No key added to ~/.ssh/authorized_keys"
-    fi
-}
-
-
 # You can add new packages here
 install_dev_tools(){
     apt update -qq


### PR DESCRIPTION
Since /home/odoo/.ssh is marked as a volume in the parent image, changes to files in the directory during docker build are being lost when a new container is created. Therefore the authorized_keys file is set directly on the host and copied over to the container.

Closes #211.