### PR TITLE
[REF] github-actions: Use exclude macosx-latest for py old, add py3.12, MacOSX M1 cache and fix build

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -18,22 +18,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
-        os: [ubuntu-latest, windows-latest, macos-13]
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
         tox_env: ["py,codecov"]
         include:
-          - python: '3.11'
-            os: macos-latest
-            tox_env: 'py,codecov'
-          - python: '3.10'
+          - python: '3.12'
             os: ubuntu-latest
             tox_env: 'check'
-          - python: '3.10'
+          - python: '3.12'
             os: ubuntu-latest
             tox_env: 'docs'
-          - python: '3.10'
+          - python: '3.12'
             os: ubuntu-latest
             tox_env: 'build'
+        exclude:
+          # macos-14 AKA macos-latest has switched to being an ARM runner, only supporting newer versions of Python
+          # https://github.com/actions/setup-python/issues/825#issuecomment-2096792396
+          - python: '3.7'
+            os: macos-latest
+          - python: '3.8'
+            os: macos-latest
+          - python: '3.9'
+            os: macos-latest
+          - python: '3.10'
+            os: macos-latest
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -46,10 +55,10 @@ jobs:
         cache: 'pip'
     - name: Cache pre-commit packages
       id: cache-pre-commit
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pre-commit
-        key: ${{ runner.os }}-py${{ matrix.python }}-pre-commit
+        key: ${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python }}-pre-commit
     - name: install dependencies
       run: |
         pip install --upgrade pip

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,10 @@
-virtualenv>=16.6.0
+build
+bump2version
+pbr  # only to generate changelog based on git commits
 pip>=19.1.1
-setuptools>=18.0.1
+setuptools >=42
 six>=1.14.0
 tox
-# only to generate changelog based on git commits
-pbr
 twine
+virtualenv>=16.6.0
 wheel

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         # uncomment if you test on these interpreters:

--- a/tox.ini
+++ b/tox.ini
@@ -74,11 +74,7 @@ commands =
 
 [testenv:build]
 skip_install = true
-deps =
-    build
-    bump2version
-    twine
-    wheel
+deps = -r{toxinidir}/requirements-dev.txt
 commands =
     python -m build --sdist --wheel --outdir dist_wo_pbr/
     python -c "import shutil;shutil.rmtree('dist/', ignore_errors=True)"


### PR DESCRIPTION
* Exclude MacOSX-latest for py old
* Add py3.12 setup compatible
* Add separated cache for MacOSX M1
* Fix build