### PR TITLE
[FIX] build.sh: Use the same environment variables for sudo commands

### DIFF
--- a/src/travis2docker/templates/build.sh
+++ b/src/travis2docker/templates/build.sh
@@ -78,7 +78,7 @@ install_dev_tools(){
         # emacs \
         # byobu \
         # multitail  # Set the terminal with red letters build the docker
-    sudo pip install -q \
+    sudo -E pip install -q \
         ipython \
         py-spy \
         virtualenv \
@@ -99,7 +99,7 @@ install_dev_tools(){
     # pre install pre-commit-vauxoo?
     # sudo su odoo -c "git init /tmp/test && cd /tmp/test && pre-commit-vauxoo -f"
     touch /home/odoo/full_test-requirements.txt
-    sudo pip install -r /home/odoo/full_test-requirements.txt
+    sudo -E pip install -r /home/odoo/full_test-requirements.txt
 
     # Keep alive the ssh server
     #   60 seconds * 360 = 21600 seconds = 6 hours


### PR DESCRIPTION
It is useful for environment variable enabled PIP_BREAK_SYSTEM_PACKAGES

Fix the following error

```txt
error: externally-managed-environment
× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.11/README.venv for more information.
note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```