### PR TITLE
WIP: [REF] build.sh: Install pg_vector dependencies

### DIFF
--- a/src/travis2docker/templates/build.sh
+++ b/src/travis2docker/templates/build.sh
@@ -131,6 +131,12 @@ EOF
 
     # Configure emacs for odoo user
     git clone --depth 1 -b master https://github.com/Vauxoo/emacs.d.git /home/odoo/.emacs.d
+
+    # Install pgvector for "ai" odoo-18.4+ module
+    VERSIONS=$(pg_lsclusters  | sed '1d' | awk '{print $1}' )
+    for version in $VERSIONS; do
+        apt install -y postgresql-$version-pgvector
+    done
 }
 
 setup_coverage() {


### PR DESCRIPTION
Similar to https://git.vauxoo.com/vauxoo/docker-postgresql/-/merge_requests/43

t2d is using the same odoo image installing psql in order to be compatible with the current runbot

So, we need to install the same package for the psql docker image

TODO: Migrate to use the psql docker image instead in the future (not priority today)