### PR TITLE
[FIX] Dockerfile_deployv: Protect mv files only if exists

### DIFF
--- a/src/travis2docker/templates/Dockerfile_deployv
+++ b/src/travis2docker/templates/Dockerfile_deployv
@@ -34,9 +34,9 @@ RUN . /home/odoo/build.sh && \
     configure_vim && \
     configure_zsh && \
     chown_all && \
-    mv /entrypoint_image /deployv_entrypoint_image && \
-    mv /entry_point.py /deployv_entry_point.py && \
-    mkdir /run/sshd
+    [ -e /entrypoint_image ] && mv /entrypoint_image /deployv_entrypoint_image ; \
+    [ -e /entry_point.py ] && mv /entry_point.py /deployv_entry_point.py ; \
+    mkdir -p /run/sshd
 
 {% for step in build_extra_steps %}
 RUN {{ step }}


### PR DESCRIPTION
New docker image missing files than old version