### PR TITLE
[IMP] travis2docker: fix permissions and simplify shell in DeployV T#93496

### DIFF
--- a/src/travis2docker/cli.py
+++ b/src/travis2docker/cli.py
@@ -274,14 +274,6 @@ def main(return_result=False):
         stdout.write('\nGenerated scripts:\n%s\n' % fname_list)
         if deployv:
             stdout.write("=" * 80)
-            stdout.write(
-                '\nUsing --deployv option you will need to run the following extra step '
-                'manually after to create the container or after running 20-run.sh script'
-            )
-            stdout.write(
-                '\ndocker exec -it --user=root CONTAINER '
-                'find /home/odoo -maxdepth 1 -not -user odoo -exec chown -R odoo:odoo {} \\;\n'
-            )
             if not default_docker_image:
                 # TODO: Add the URL to open the pipelines
                 stdout.write(

--- a/src/travis2docker/templates/Dockerfile_deployv
+++ b/src/travis2docker/templates/Dockerfile_deployv
@@ -2,8 +2,6 @@ FROM {{ image  }}
 
 ARG HOME=/home/odoo
 
-# rm -rf /home/odoo/.ssh
-
 {%- for src, dest in copies or [] %}
 COPY {{ src }} {{ dest }}
 {% endfor -%}
@@ -43,10 +41,8 @@ RUN . /home/odoo/build.sh && \
 RUN {{ step }}
 {% endfor %}
 
-USER {{ user }}
-
 # TODO: Use .profile as bash profiler by default
 
-ENTRYPOINT /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh", "--docker"]
 
 WORKDIR $MAIN_REPO_FULL_PATH


### PR DESCRIPTION
The entrypoint used for DeployV-based projects now automatically fixes ownership for files in `/home/odoo` that cannot be adjusted at build time because some paths are declared as volumes in the parent DeployV images (e.g. `~/.ssh`).

It also starts an interactive shell (`bash`) when `START_ODOO=0`, so it is no longer required to override the entrypoint with `--entrypoint bash` when running `t2d` for development purposes.

Closes #217