### PR TITLE
[REF] entrypoint_deployv: Compatible with saas-18.3+ (future odoo-19.0) to use new with-demo parameter

### DIFF
--- a/src/travis2docker/templates/entrypoint_deployv.sh
+++ b/src/travis2docker/templates/entrypoint_deployv.sh
@@ -104,6 +104,14 @@ def start_odoo():
     except subprocess.CalledProcessError:
         database_created = False
 
+    configpy = "/home/odoo/instance/odoo/odoo/tools/config.py"
+    if os.path.isfile(configpy):
+        with open(configpy) as f_configpy:
+            for line in f_configpy:
+                if "--with-demo" in line:
+                    cmd.extend(["--with-demo"])
+                    break
+
     if not database_created:
         cmd.extend(["-i", ",".join(modules), "--workers=0", "--stop-after-init"])
         if test_enable:


### PR DESCRIPTION
Based on the following future change for odoo-19.0:
 - [[IMP] core: no longer load demo data by default](https://github.com/odoo/odoo/pull/194585)

And inspired by original runbot code to set parameters:
 - https://github.com/odoo/runbot/blob/91834a6b340bb379df06149/runbot/models/build.py#L1164-L1168

We are checking if this new parameter is needed for the odoo deployed in this image


This change apply only for runbot and local instances generated with t2d

TODO:
- [ ] Fix vxci
- [ ] test dummy MR odoo-out-of-the-box