### PR TITLE
[FIX] travis2docker: don't overwrite existing keys

### DIFF
--- a/src/travis2docker/travis2docker.py
+++ b/src/travis2docker/travis2docker.py
@@ -402,5 +402,5 @@ class Travis2Docker(object):
         with open(to_copy, "r", encoding="utf-8") as key_fd:
             pub_key = key_fd.read()
 
-        with open(os.path.join(self.curr_work_path, ".ssh", "authorized_keys"), "w", encoding="utf-8") as auth_fd:
+        with open(os.path.join(self.curr_work_path, ".ssh", "authorized_keys"), "a", encoding="utf-8") as auth_fd:
             auth_fd.write(pub_key)


### PR DESCRIPTION
When granting access to SSH keys by adding the same public key to the `authorized_keys` file, the existing file was being overwritten, because the mode "w" was being used instead of "a". This is the equivalent of using `>` instead of `>>` in shell.

To solve this, the "a" mode is now used.