### PR TITLE
[FIX] travis2docker: automatically fix DeployV file ownership

### DIFF
--- a/src/travis2docker/cli.py
+++ b/src/travis2docker/cli.py
@@ -273,24 +273,15 @@ def main(return_result=False):
     if fname_scripts:
         fname_list = "- " + "\n- ".join(fname_scripts)
         stdout.write("\nGenerated scripts:\n%s\n" % fname_list)
-        if deployv:
+        if deployv and not default_docker_image:
             stdout.write("=" * 80)
+            # TODO: Add the URL to open the pipelines
             stdout.write(
-                "\nUsing --deployv option you will need to run the following extra step "
-                "manually after to create the container or after running 20-run.sh script"
+                '\nTIP: Use the parameter "--docker-image=quay.io/vauxoo/PROJECT:TAG" '
+                'get the PROJECT:TAG info in your "build_docker" pipeline similar to '
+                '\n"... INFO  - deployv.deployv_addon_gitlab_tools.common.common.push_image - '
+                'Pushing image ... to quay.io/vauxoo/PROJECT:TAG"\n'
             )
-            stdout.write(
-                "\ndocker exec -it --user=root CONTAINER "
-                "find /home/odoo -maxdepth 1 -not -user odoo -exec chown -R odoo:odoo {} \\;\n"
-            )
-            if not default_docker_image:
-                # TODO: Add the URL to open the pipelines
-                stdout.write(
-                    '\nTIP: Use the parameter "--docker-image=quay.io/vauxoo/PROJECT:TAG" '
-                    'get the PROJECT:TAG info in your "build_docker" pipeline similar to '
-                    '\n"... INFO  - deployv.deployv_addon_gitlab_tools.common.common.push_image - '
-                    'Pushing image ... to quay.io/vauxoo/PROJECT:TAG"\n'
-                )
             stdout.write("=" * 80)
     else:
         stdout.write("\nNo scripts were generated.")

--- a/src/travis2docker/templates/20-run.sh
+++ b/src/travis2docker/templates/20-run.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 export IMAGE={{ image }}
-docker run {{ extra_params }} $1 -itP $IMAGE $2
+CONTAINER=$(docker run {{ extra_params }} $1 -ditP $IMAGE $2)
+
+# Some files under /home/odoo end up owned by root or other users (declared VOLUMEs and
+# files shared into the container); fix their ownership in the background so we can attach ASAP
+docker exec --user=root "$CONTAINER" find /home/odoo -maxdepth 2 -not -user odoo -exec chown -R odoo:odoo {} + &
+docker attach "$CONTAINER"
 {{ extra_cmds }}


### PR DESCRIPTION
Some files under `/home/odoo` are owned by root or other users due to declared volumes and files shared into the container. This required users to manually restore their ownership after starting the container.

To fix this, run the ownership correction automatically from `20-run.sh` once the container is running, and remove the corresponding manual instructions from the generated output.

Closes #217