### PR TITLE
[IMP] travis2docker: add local user binaries to PATH

### DIFF
--- a/src/travis2docker/templates/Dockerfile_deployv
+++ b/src/travis2docker/templates/Dockerfile_deployv
@@ -31,6 +31,7 @@ RUN . /home/odoo/build.sh && \
     git_set_remote && \
     bash_colorized && \
     setup_coverage && \
+    local_bin_path && \
     configure_vim && \
     configure_zsh && \
     chown_all && \

--- a/src/travis2docker/templates/build.sh
+++ b/src/travis2docker/templates/build.sh
@@ -159,6 +159,15 @@ setup_coverage() {
   echo "export MODULES2INSTALL=$(cd ${MAIN_REPO_FULL_PATH} && find * -name "__manifest__.py" -printf "%h,")" >> ${HOME}/.bashrc
 }
 
+local_bin_path(){
+    # Add ~/.local/bin to PATH at shell startup if it exists and is not already there
+    cat >> ${HOME}/.bashrc << 'EOF'
+if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+EOF
+}
+
 
 bash_colorized(){
     cat >> ~/.bashrc << 'EOF'


### PR DESCRIPTION
Add `~/.local/bin` to `PATH` during shell startup when the directory exists and is not already included.

This avoids requiring an additional PATH configuration step when tools such as MinIO Client or Claude are installed inside DeployV containers.