### PR TITLE
[FIX] travis2docker: preserve detached run behavior

### DIFF
--- a/src/travis2docker/templates/20-run.sh
+++ b/src/travis2docker/templates/20-run.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 export IMAGE={{ image }}
+# Run detached so we capture the exact container id; we re-attach below unless the caller
+# asked for a detached run (-d/--detach), in which case we just print the id like docker run.
 CONTAINER=$(docker run {{ extra_params }} $1 -ditP $IMAGE $2)
 
 # Some files under /home/odoo end up owned by root or other users (declared VOLUMEs and
-# files shared into the container); fix their ownership in the background so we can attach ASAP
+# files shared into the container); fix their ownership in the background so we can attach ASAP.
 docker exec --user=root "$CONTAINER" find /home/odoo -maxdepth 2 -not -user odoo -exec chown -R odoo:odoo {} + &
-docker attach "$CONTAINER"
+
+# Detach intent: a single-dash cluster holding a d (-d, -dit, -itd...) or --detach.
+detach_re='[[:space:]](-[a-zA-Z]*d[a-zA-Z]*|--detach)[[:space:]]'
+if [[ " {{ extra_params }} $1 " =~ $detach_re ]]; then
+    wait
+    echo "$CONTAINER"
+else
+    docker attach "$CONTAINER"
+fi
 {{ extra_cmds }}


### PR DESCRIPTION
The previous ownership fix [1] changed `20-run.sh` to:
- start the container detached
- correct file ownership in the background
- attach to the container afterward

However, it did not consider callers explicitly passing `-d` or `--detach`. In those cases, the script still attached to the container, changing the previous behavior of `docker run`.

To fix this, detect the detach option in both the configured extra parameters and the runtime arguments. When present, wait for the ownership correction to finish and print the container ID instead of attaching, matching the behavior of a detached `docker run`.

[1]: https://github.com/Vauxoo/travis2docker/commit/0933fd659d7bfee62a6900629431358aa5378a6c