### PR TITLE
[REF] build.sh: Replace diff-highlight with git-delta for git pager

### DIFF
--- a/src/travis2docker/templates/build.sh
+++ b/src/travis2docker/templates/build.sh
@@ -99,7 +99,6 @@ install_dev_tools(){
         virtualenv \
         ipdb \
         pre-commit-vauxoo \
-        diff-highlight \
         pg-activity \
         nodeenv \
         pdbpp
@@ -116,6 +115,11 @@ install_dev_tools(){
     touch /home/odoo/full_test-requirements.txt
     sudo -E pip install -r /home/odoo/full_test-requirements.txt
 
+    # Install git-delta from .deb since not all Ubuntu versions ship the package
+    GIT_DELTA_VERSION=0.18.2
+    wget -q https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/git-delta_${GIT_DELTA_VERSION}_$(dpkg --print-architecture).deb -O /tmp/git-delta.deb && \
+        apt install -qqq -y /tmp/git-delta.deb || true
+
     # Keep alive the ssh server
     #   60 seconds * 360 = 21600 seconds = 6 hours
     # https://www.bjornjohansen.no/ssh-timeout
@@ -126,13 +130,16 @@ install_dev_tools(){
     wget -O /tmp/ngrok.tgz https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-linux-amd64.tgz && \
     tar xvzf /tmp/ngrok.tgz -C /usr/local/bin || true
 
-    # Configure diff-highlight on git after install
-    cat >> /etc/gitconfig << EOF
-[pager]
-    log = diff-highlight | less
-    show = diff-highlight | less
-    diff = diff-highlight | less
-EOF
+    # Configure color for git diff if git-delta is already installed
+    if command -v delta >/dev/null 2>&1; then
+        git config --system core.pager delta
+        git config --system interactive.diffFilter "delta --color-only"
+
+        git config --system delta.navigate true
+        git config --system delta.line-numbers true
+        git config --system delta.syntax-theme DarkNeon
+        git config --system delta.keep-plus-minus-markers true
+    fi
     cat >> /etc/multitail.conf << EOF
 # Odoo log
 colorscheme:odoo


### PR DESCRIPTION
- Install `git-delta` instead of the unmaintained `diff-highlight` package
  - Latest change 2years ago https://github.com/tk0miya/diff-highlight
- Configure delta as the default Git pager
- Enable line numbers and navigation
- Set DarkNeon as the default syntax theme
- Enable zdiff3 merge conflict style
- Fix the following warning running `git diff`

```txt
    /usr/lib/python3/dist-packages/highlights/command.py:33: SyntaxWarning: invalid escape sequence '\['
    stripped = re.sub('\x1b\[[0-9;]*m', '', rawline.rstrip("\r\n"))
    /usr/lib/python3/dist-packages/highlights/command.py:36: SyntaxWarning: invalid escape sequence '\w'
    if re.match('^(@|commit \w+$)', stripped):
    /usr/lib/python3/dist-packages/highlights/command.py:39: SyntaxWarning: invalid escape sequence '\-'
    if not re.match('^(?:[ +\-@\\\\]|diff)', stripped):
    /usr/lib/python3/dist-packages/highlights/pprint.py:181: SyntaxWarning: invalid escape sequence '\s'
    is_word = lambda s: re.match('^(%s+|\s+)$' % chars, s[0])
    /usr/lib/python3/dist-packages/highlights/pprint.py:183: SyntaxWarning: invalid escape sequence '\-'
    marks = '[ !"#$%&\'()*+,\-./:;<=>?@\[\\]^_{|}~]'
    /usr/lib/python3/dist-packages/highlights/pprint.py:186: SyntaxWarning: invalid escape sequence '\s'
    is_mark = lambda s: re.match('^(%s+|\s+)$' % marks, s[0])
    /usr/lib/python3/dist-packages/highlights/pprint.py:232: SyntaxWarning: invalid escape sequence '\s'
    if (inserted[0][0] == "+" and re.match('^\s*$', inserted[1][0]) and
    /usr/lib/python3/dist-packages/highlights/pprint.py:233: SyntaxWarning: invalid escape sequence '\s'
    deleted[0][0] == "-" and re.match('^\s*$', deleted[1][0])):
```

Before:
 - <img width="762" height="397" alt="Screenshot 2026-07-17 at 4 14 55 p m" src="https://github.com/user-attachments/assets/08c891ae-12d3-488f-ae19-16d8b646cfba" />

After:
 - <img width="759" height="815" alt="Screenshot 2026-07-17 at 4 14 45 p m" src="https://github.com/user-attachments/assets/7681184b-eb09-4a4e-92c5-a994ba186e37" />
