### PR TITLE
[REF] build.sh: Set `with_demo` to True in odoo.conf during build

### DIFF
--- a/src/travis2docker/templates/build.sh
+++ b/src/travis2docker/templates/build.sh
@@ -46,6 +46,7 @@ odoo_conf(){
     fi
     $ENTRYPOINT run true
     sed -i '/db_host\|db_password\|db_user\|workers\|list_db/d' $ODOO_CONF
+    sed -i 's/\(with_demo\s*=\s*\)False/\1True/' $ODOO_CONF
     su odoo -c "mkdir -p $ODOORC_DATA_DIR"
 }
 

--- a/src/travis2docker/templates/entrypoint_deployv.sh
+++ b/src/travis2docker/templates/entrypoint_deployv.sh
@@ -104,14 +104,6 @@ def start_odoo():
     except subprocess.CalledProcessError:
         database_created = False
 
-    configpy = "/home/odoo/instance/odoo/odoo/tools/config.py"
-    if os.path.isfile(configpy):
-        with open(configpy) as f_configpy:
-            for line in f_configpy:
-                if "--with-demo" in line:
-                    cmd.extend(["--with-demo"])
-                    break
-
     if not database_created:
         cmd.extend(["-i", ",".join(modules), "--workers=0", "--stop-after-init"])
         if test_enable:


### PR DESCRIPTION
Starting from Odoo 19.0, the with_demo parameter is automatically added to the configuration file with a value of False. Force it to True with sed to preserve the expected behavior of installing with demonstration data.

Also, reverted
[REF] entrypoint_deployv: Compatible with saas-18.3+ (future odoo-19.0) to use new with-demo parameter (#224) This reverts commit caa9c7aa958c6fd3e58b3a216a9bc120997a673f
and PR https://github.com/Vauxoo/travis2docker/pull/224

Since it is enabling the same parameter from command instead

But changing the Odoo config file is enough